### PR TITLE
add ember-try scenarios that fail with deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,8 @@ jobs:
           - ember-default-with-jquery
           - embroider-safe
           - embroider-optimized
+          - no-deprecations
+          - ember-release-no-deprecations
         allow-failure: [false]
         include:
           - ember-try-scenario: ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -82,6 +82,23 @@ module.exports = async function () {
       },
       embroiderSafe(),
       embroiderOptimized(),
+      {
+        name: 'no-deprecations',
+        npm: {
+          devDependencies: {
+            'ember-deprecation-error': '*',
+          },
+        },
+      },
+      {
+        name: 'ember-release-no-deprecations',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('release'),
+            'ember-deprecation-error': '*',
+          },
+        },
+      },
     ],
   };
 };


### PR DESCRIPTION
With Ember 4.0 just around the corner there I'm in a bit of a "deprecation hunting" exercise. This PR adds 2 ember-try scenarios that will fail if there are any deprecations 👍 

Let me know if you think this would be useful  