### PR TITLE
Revert FastBook workarounds in cdn providers

### DIFF
--- a/.changeset/late-olives-change.md
+++ b/.changeset/late-olives-change.md
@@ -1,0 +1,8 @@
+---
+'@responsive-image/ember': major
+'@responsive-image/cdn': patch
+---
+
+Remove FastBoot related workarounds in `imgix` image CDN provider
+
+Instead of working around a [known issue](https://github.com/ember-fastboot/ember-cli-fastboot/issues/816) in the actual runtime code, users need to add a FastBoot config to expose needed globals like `URL` or `URLSearchParams`, as documented in the [Ember guide](https://responsive-image.dev/frameworks/ember#fastboot).

--- a/apps/docs/src/frameworks/ember.md
+++ b/apps/docs/src/frameworks/ember.md
@@ -165,3 +165,21 @@ declare module '@glint/environment-ember-loose/registry' {
 ```
 
 If you are using one of the [build plugins](../build/index.md), also make sure to have the necessary ambient declaration for image imports in place as described [here](../usage/local-images.md#typescript)!
+
+## FastBoot
+
+Server-side rendering using FastBoot is fully supported, but might require some tweaks.
+
+If you are using [remote images](../usage/remote-images.md) using some of the providers for [image CDNs](../cdn/index.md), they require exposing some browser globals to the FastBoot sandbox. FastBoot does not allow access to globals that are available in both browser and node.js environments by default, like `fetch` or `URLSearchParams`, and `URL` has some [known issue](https://github.com/ember-fastboot/ember-cli-fastboot/issues/816). To workaround these deficiencies, you need to explicitly expose some needed globals by creating a `config/fastboot.js` file in your app:
+
+```js
+'use strict';
+
+module.exports = function () {
+  return {
+    buildSandboxGlobals(defaultGlobals) {
+      return { ...defaultGlobals, URL, URLSearchParams };
+    },
+  };
+};
+```

--- a/apps/ember-test-app/config/fastboot-testing.js
+++ b/apps/ember-test-app/config/fastboot-testing.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = function () {
+  return {
+    buildSandboxGlobals(defaultGlobals) {
+      return { ...defaultGlobals, URL, URLSearchParams };
+    },
+  };
+};

--- a/apps/ember-test-app/config/fastboot.js
+++ b/apps/ember-test-app/config/fastboot.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = function () {
+  return {
+    buildSandboxGlobals(defaultGlobals) {
+      return { ...defaultGlobals, URL, URLSearchParams };
+    },
+  };
+};

--- a/packages/cdn/src/imgix.ts
+++ b/packages/cdn/src/imgix.ts
@@ -30,14 +30,7 @@ export function imgixProvider(
   return {
     imageTypes: options.formats ?? ['png', 'jpeg', 'webp'],
     imageUrlFor(width: number, type: ImageType = 'jpeg'): string {
-      // In the FastBoot sandbox, the URL global is shadowed by the `url` module. :-(
-      // See https://github.com/ember-fastboot/ember-cli-fastboot/issues/816
-      const URLConstructor: typeof URL =
-        typeof URL === 'function' ? URL : (URL as { URL: typeof URL }).URL;
-
-      const url = new URLConstructor(
-        `https://${domain}/${normalizeSrc(image)}`,
-      );
+      const url = new URL(`https://${domain}/${normalizeSrc(image)}`);
       const params = url.searchParams;
 
       params.set('fm', formatMap[type] ?? type);


### PR DESCRIPTION
Instead of working around a [known issue](https://github.com/ember-fastboot/ember-cli-fastboot/issues/816) in the actual runtime code, users need to add a FastBoot config to expose needed globals like `URL` or `URLSearchParams`, as documented in the [Ember guide](https://responsive-image.dev/frameworks/ember#fastboot).