### PR TITLE
Better workaround for lazy loading issue in Firefox

### DIFF
--- a/.changeset/lemon-queens-sneeze.md
+++ b/.changeset/lemon-queens-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@responsive-image/ember": patch
+---
+
+Better workaround for lazy loading issue in Firefox


### PR DESCRIPTION
FF loads images eagerly when setting src attribute. The previous workaround of delaying can be improved with a much simpler one, by just setting the loading attribute before src.