### PR TITLE
Solid: fix reactivity when changing props

### DIFF
--- a/packages/solid/src/responsive-image.tsx
+++ b/packages/solid/src/responsive-image.tsx
@@ -45,11 +45,6 @@ interface ImageSource {
   sizes?: string | undefined;
 }
 
-enum Layout {
-  RESPONSIVE = 'responsive',
-  FIXED = 'fixed',
-}
-
 const PIXEL_DENSITIES = [1, 2];
 
 // determines the order of sources, prefereing next-gen formats over legacy
@@ -64,90 +59,91 @@ export const ResponsiveImage: Component<ResponsiveImageProps> = (props) => {
   const [isLoaded, setLoaded] = createSignal(false);
   const [args, attributes] = splitProps(props, responsiveImageArgs);
 
-  const layout =
-    args.width === undefined && args.height === undefined
-      ? Layout.RESPONSIVE
-      : Layout.FIXED;
+  const isResponsiveLayout = () =>
+    args.width === undefined && args.height === undefined;
 
-  let width: number | undefined = undefined;
-
-  if (layout === Layout.RESPONSIVE) {
-    width = getDestinationWidthBySize(args.size);
-  } else {
-    if (args.width) {
-      width = args.width;
+  const width = () => {
+    if (isResponsiveLayout()) {
+      return getDestinationWidthBySize(args.size);
     } else {
-      const ar = args.src.aspectRatio;
-      if (ar !== undefined && ar !== 0 && args.height !== undefined) {
-        width = args.height * ar;
+      if (args.width) {
+        return args.width;
+      } else {
+        const ar = args.src.aspectRatio;
+        if (ar !== undefined && ar !== 0 && args.height !== undefined) {
+          return args.height * ar;
+        }
       }
     }
-  }
 
-  let height: number | undefined = undefined;
+    return undefined;
+  };
 
-  if (args.height) {
-    height = args.height;
-  }
+  const height = () => {
+    if (args.height) {
+      return args.height;
+    }
 
-  const ar = args.src.aspectRatio;
-  if (
-    height === undefined &&
-    ar !== undefined &&
-    ar !== 0 &&
-    width !== undefined
-  ) {
-    height = Math.round(width / ar);
-  }
+    const ar = args.src.aspectRatio;
+    const w = width();
+    if (ar !== undefined && ar !== 0 && w !== undefined) {
+      return Math.round(w / ar);
+    }
 
-  const src = args.src.imageUrlFor(width ?? 640);
-  let sources: ImageSource[];
+    return undefined;
+  };
 
-  if (layout === Layout.RESPONSIVE) {
-    sources = args.src.imageTypes.map((type) => {
-      let widths = args.src.availableWidths;
-      if (!widths) {
-        widths = env.deviceWidths;
-      }
-      const sources: string[] = widths.map((width) => {
-        const url = args.src.imageUrlFor(width, type);
-        return `${url} ${width}w`;
-      });
+  const src = () => args.src.imageUrlFor(width() ?? 640);
 
-      return {
-        srcset: sources.join(', '),
-        sizes: args.sizes ?? (args.size ? `${args.size}vw` : undefined),
-        type,
-        mimeType: `image/${type}`,
-      };
-    });
-  } else {
-    if (width === undefined) {
-      sources = [];
-    } else {
-      sources = args.src.imageTypes.map((type) => {
-        const sources: string[] = PIXEL_DENSITIES.map((density) => {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          const url = args.src.imageUrlFor(width * density, type)!;
-
-          return `${url} ${density}x`;
-        }).filter((source) => source !== undefined);
+  const sources = (): ImageSource[] => {
+    if (isResponsiveLayout()) {
+      return args.src.imageTypes.map((type) => {
+        let widths = args.src.availableWidths;
+        if (!widths) {
+          widths = env.deviceWidths;
+        }
+        const sources: string[] = widths.map((width) => {
+          const url = args.src.imageUrlFor(width, type);
+          return `${url} ${width}w`;
+        });
 
         return {
           srcset: sources.join(', '),
+          sizes: args.sizes ?? (args.size ? `${args.size}vw` : undefined),
           type,
           mimeType: `image/${type}`,
         };
       });
-    }
-  }
+    } else {
+      const w = width();
+      if (w === undefined) {
+        return [];
+      } else {
+        return args.src.imageTypes.map((type) => {
+          const sources: string[] = PIXEL_DENSITIES.map((density) => {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const url = args.src.imageUrlFor(w * density, type)!;
 
-  const sourcesSorted = sources.sort(
-    (a, b) => (typeScore.get(b.type) ?? 0) - (typeScore.get(a.type) ?? 0),
-  );
+            return `${url} ${density}x`;
+          }).filter((source) => source !== undefined);
+
+          return {
+            srcset: sources.join(', '),
+            type,
+            mimeType: `image/${type}`,
+          };
+        });
+      }
+    }
+  };
+
+  const sourcesSorted = () =>
+    sources().sort(
+      (a, b) => (typeScore.get(b.type) ?? 0) - (typeScore.get(a.type) ?? 0),
+    );
 
   const classNames = () => {
-    const classNames = [`ri-${layout}`];
+    const classNames = [`ri-${isResponsiveLayout() ? 'responsive' : 'fixed'}`];
     const lqip = args.src.lqip;
     if (lqip && !isLoaded()) {
       classNames.push(`ri-lqip-${lqip.type}`);
@@ -159,53 +155,47 @@ export const ResponsiveImage: Component<ResponsiveImageProps> = (props) => {
     return classNames;
   };
 
-  const blurhashMeta = isLqipBlurhash(args.src.lqip)
-    ? args.src.lqip
-    : undefined;
-  let blurhashStyles: (() => JSX.CSSProperties | undefined) | undefined =
-    undefined;
+  const blurhashMeta = () =>
+    isLqipBlurhash(args.src.lqip) ? args.src.lqip : undefined;
+  const [blurhashLib] = createResource(() => {
+    return import('@responsive-image/core/blurhash/decode');
+  });
+  const blurhashStyles = (): JSX.CSSProperties | undefined => {
+    const meta = blurhashMeta();
+    if (isServer || !meta || isLoaded()) {
+      return undefined;
+    }
 
-  if (!isServer && blurhashMeta) {
-    const [blurhashLib] = createResource(() => {
-      return import('@responsive-image/core/blurhash/decode');
-    });
+    const { hash, width, height } = meta;
+    const uri = blurhashLib()?.decode2url(hash, width, height);
 
-    blurhashStyles = () => {
-      if (isLoaded()) {
-        return undefined;
-      }
+    if (!uri) {
+      return undefined;
+    }
 
-      const { hash, width, height } = blurhashMeta;
-      const uri = blurhashLib()?.decode2url(hash, width, height);
-
-      if (!uri) {
-        return undefined;
-      }
-
-      return {
-        'background-image': `url("${uri}")`,
-        'background-size': 'cover',
-      };
+    return {
+      'background-image': `url("${uri}")`,
+      'background-size': 'cover',
     };
-  }
+  };
 
   return (
     <picture>
-      {sourcesSorted.map((s) => (
+      {sourcesSorted().map((s) => (
         <source srcset={s.srcset} type={s.mimeType} sizes={s.sizes} />
       ))}
       <img
-        width={width}
-        height={height}
+        width={width()}
+        height={height()}
         class={classNames().join(' ')}
         loading="lazy"
         decoding="async"
-        src={src}
+        src={src()}
         {...attributes}
-        data-ri-bh={blurhashMeta?.hash}
-        data-ri-bh-w={blurhashMeta?.width}
-        data-ri-bh-h={blurhashMeta?.height}
-        style={blurhashStyles?.()}
+        data-ri-bh={blurhashMeta()?.hash}
+        data-ri-bh-w={blurhashMeta()?.width}
+        data-ri-bh-h={blurhashMeta()?.height}
+        style={blurhashStyles()}
         on:load={() => setLoaded(true)}
       />
     </picture>


### PR DESCRIPTION
Mostly props like `src` would not change, but the component should be able to react to changes nevertheless. The existing implementation was not using derived signals everywhere props could change.