### PR TITLE
fix lint:package for svelte package

### DIFF
--- a/packages/svelte/turbo.json
+++ b/packages/svelte/turbo.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://turborepo.org/schema.json",
+	"extends": ["//"],
+	"tasks": {
+		"lint": {
+			"dependsOn": ["build"]
+		}
+	}
+}


### PR DESCRIPTION
It expects to see build output when it checks exports, so we need to build first