### PR TITLE
Add support for Fastly Image Optimizer as a CDN

### DIFF
--- a/.changeset/dirty-jars-cheat.md
+++ b/.changeset/dirty-jars-cheat.md
@@ -1,0 +1,7 @@
+---
+'@responsive-image/ember': minor
+'@responsive-image/cdn': minor
+'@responsive-image/core': patch
+---
+
+Add support for Fastly IO as a CDN

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -110,6 +110,7 @@ export default defineConfig({
         base: '/cdn',
         items: [
           { text: 'Cloudinary', link: '/cloudinary' },
+          { text: 'Fastly', link: '/fastly' },
           { text: 'Imgix', link: '/imgix' },
           { text: 'Netlify', link: '/netlify' },
         ],

--- a/apps/docs/src/cdn/fastly.md
+++ b/apps/docs/src/cdn/fastly.md
@@ -1,0 +1,421 @@
+# Fastly
+
+The [Fastly Image Optimizer](https://www.fastly.com/documentation/reference/io/) (IO)
+is supported by using a helper function in the `@responsive-image/cdn` package.
+
+## Setup
+
+Make sure you have the `@responsive-image/cdn` package installed:
+
+::: code-group
+
+```bash [npm]
+npm install @responsive-image/cdn
+```
+
+```bash [yarn]
+yarn add @responsive-image/cdn
+```
+
+```bash [pnpm]
+pnpm add @responsive-image/cdn
+```
+
+:::
+
+You need to specify your `domain` in your configuration, which you can set up in your application (e.g. `app.js`):
+
+```js
+import { setConfig } from '@responsive-image/core';
+
+setConfig('cdn', {
+  fastly: {
+    domain: 'images.mydomain.com',
+  },
+});
+```
+
+:::info
+
+By default `fastly` is configured to use the `auto` format.
+This uses [content negotiation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Content_negotiation)
+to use the optimal image format for any given browser.
+You can change this behavior with the `defaultFormats` configuration.
+
+:::
+
+## Usage
+
+> [!IMPORTANT]
+> Please make sure you have read the section on [remote images](../usage/remote-images.md) first.
+
+Use the `fastly` provider function passing the pathname to the image on the CDN, and pass the return value to the [image component](../usage/component.md):
+
+::: code-group
+
+```gjs [Ember .gjs]
+import { ResponsiveImage } from '@responsive-image/ember';
+import { fastly } from '@responsive-image/cdn';
+
+<template>
+  <ResponsiveImage @src={{fastly 'path/to/uploaded/image.jpg'}} />
+</template>
+```
+
+```hbs [Ember .hbs]
+<ResponsiveImage
+  @src={{responsive-image-fastly 'path/to/uploaded/image.jpg'}}
+/>
+```
+
+```ts [Lit]
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { fastly } from '@responsive-image/cdn';
+import '@responsive-image/wc';
+
+@customElement('my-app')
+export class MyApp extends LitElement {
+  render() {
+    return html`<responsive-image
+      .src=${fastly('path/to/uploaded/image.jpg')}
+    ></responsive-image>`;
+  }
+}
+```
+
+```tsx [Solid]
+import { ResponsiveImage } from '@responsive-image/solid';
+import { fastly } from '@responsive-image/cdn';
+
+export default function MyApp() {
+  return <ResponsiveImage src={fastly('path/to/uploaded/image.jpg')} />;
+}
+```
+
+```svelte [Svelte]
+<script>
+  import { ResponsiveImage } from '@responsive-image/svelte';
+  import { fastly } from '@responsive-image/cdn';
+</script>
+
+<ResponsiveImage src={fastly('path/to/uploaded/image.jpg')} />
+```
+
+:::
+
+### Aspect Ratio
+
+For the image component to be able to render `width` and `height` attributes to prevent layout shifts after loading has completed, it needs to know the aspect ratio of the source image. Unlike [local images](../usage/local-images.md) it cannot know this upfront for remote images, that's why it is recommended to supply the `aspectRatio` parameter if possible:
+
+::: code-group
+
+```gjs [Ember .gjs]
+import { ResponsiveImage } from '@responsive-image/ember';
+import { fastly } from '@responsive-image/cdn';
+
+<template>
+  <ResponsiveImage
+    @src={{fastly
+      '/path/to/image.jpg'
+      aspectRatio=1.5
+    }}
+  />
+</template>
+```
+
+```hbs [Ember .hbs]
+<ResponsiveImage
+  @src={{responsive-image-fastly '/path/to/image.jpg' aspectRatio=1.5}}
+/>
+```
+
+```ts [Lit]
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { fastly } from '@responsive-image/cdn';
+import '@responsive-image/wc';
+
+@customElement('my-app')
+export class MyApp extends LitElement {
+  render() {
+    return html`<responsive-image
+      .src=${fastly('/path/to/image.jpg', {
+        aspectRatio: 1.5,
+      })}
+    ></responsive-image>`;
+  }
+}
+```
+
+```tsx [Solid]
+import { ResponsiveImage } from '@responsive-image/solid';
+import { fastly } from '@responsive-image/cdn';
+
+export default function MyApp() {
+  return (
+    <ResponsiveImage
+      src={fastly('path/to/uploaded/image.jpg', {
+        aspectRatio: 1.5,
+      })}
+    />
+  );
+}
+```
+
+```svelte [Svelte]
+<script>
+  import { ResponsiveImage } from '@responsive-image/svelte';
+  import { fastly } from '@responsive-image/cdn';
+</script>
+
+<ResponsiveImage
+  src={fastly('path/to/uploaded/image.jpg', {
+    aspectRatio: 1.5,
+  })}
+/>
+```
+
+:::
+
+### Custom parameters
+
+Besides the transformations that the addon itself implicitly adds (related to resizing images)
+you can add your own [parameters](https://www.fastly.com/documentation/reference/io/) by passing a `params` object:
+
+::: code-group
+
+```gjs [Ember .gjs]
+import { ResponsiveImage } from '@responsive-image/ember';
+import { fastly } from '@responsive-image/cdn';
+
+<template>
+  <ResponsiveImage
+    @src={{fastly
+      'path/to/uploaded/image.jpg'
+      params=(hash orient='l' saturation=-100)
+    }}
+  />
+</template>
+```
+
+```hbs [Ember .hbs]
+<ResponsiveImage
+  @src={{responsive-image-fastly
+    'path/to/uploaded/image.jpg'
+    params=(hash orient='l' saturation=-100)
+  }}
+/>
+```
+
+```ts [Lit]
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { fastly } from '@responsive-image/cdn';
+import '@responsive-image/wc';
+
+@customElement('my-app')
+export class MyApp extends LitElement {
+  render() {
+    return html`<responsive-image
+      .src=${fastly('path/to/uploaded/image.jpg', {
+        orient: 'l',
+        saturation: -100,
+      })}
+    ></responsive-image>`;
+  }
+}
+```
+
+```tsx [Solid]
+import { ResponsiveImage } from '@responsive-image/solid';
+import { fastly } from '@responsive-image/cdn';
+
+export default function MyApp() {
+  return (
+    <ResponsiveImage
+      src={fastly('path/to/uploaded/image.jpg', {
+        orient: 'l',
+        saturation: -100,
+      })}
+    />
+  );
+}
+```
+
+```svelte [Svelte]
+<script>
+  import { ResponsiveImage } from '@responsive-image/svelte';
+  import { fastly } from '@responsive-image/cdn';
+</script>
+
+<ResponsiveImage
+  src={fastly('path/to/uploaded/image.jpg', {
+    orient: 'l',
+    saturation: -100,
+  })}
+/>
+```
+
+:::
+
+### Quality
+
+Use the `quality` parameter to pass a custom [quality](https://docs.fastly.com/apis/rendering/format/q) setting
+instead of the default `auto`:
+
+::: code-group
+
+```gjs [Ember .gjs]
+import { ResponsiveImage } from '@responsive-image/ember';
+import { fastly } from '@responsive-image/cdn';
+
+<template>
+  <ResponsiveImage
+    @src={{fastly
+      'path/to/uploaded/image.jpg'
+      quality=50
+    }}
+  />
+</template>
+```
+
+```hbs [Ember .hbs]
+<ResponsiveImage
+  @src={{responsive-image-fastly 'path/to/uploaded/image.jpg' quality=50}}
+/>
+```
+
+```ts [Lit]
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { fastly } from '@responsive-image/cdn';
+import '@responsive-image/wc';
+
+@customElement('my-app')
+export class MyApp extends LitElement {
+  render() {
+    return html`<responsive-image
+      .src=${fastly('path/to/uploaded/image.jpg', {
+        quality: 50,
+      })}
+    ></responsive-image>`;
+  }
+}
+```
+
+```tsx [Solid]
+import { ResponsiveImage } from '@responsive-image/solid';
+import { fastly } from '@responsive-image/cdn';
+
+export default function MyApp() {
+  return (
+    <ResponsiveImage
+      src={fastly('path/to/uploaded/image.jpg', {
+        quality: 50,
+      })}
+    />
+  );
+}
+```
+
+```svelte [Svelte]
+<script>
+  import { ResponsiveImage } from '@responsive-image/svelte';
+  import { fastly } from '@responsive-image/cdn';
+</script>
+
+<ResponsiveImage
+  src={fastly('path/to/uploaded/image.jpg', {
+    quality: 50,
+  })}
+/>
+```
+
+:::
+
+### Image formats
+
+By default, a modern image format (webp) is referenced in the generated `<source>` tags.
+You can tweak that using the `formats` argument:
+
+::: code-group
+
+```gjs [Ember .gjs]
+import { ResponsiveImage } from '@responsive-image/ember';
+import { fastly } from '@responsive-image/cdn';
+
+<template>
+  <ResponsiveImage
+    @src={{fastly
+      'path/to/uploaded/image.jpg'
+      formats=(array 'webp' 'avif')
+    }}
+  />
+</template>
+```
+
+```hbs [Ember .hbs]
+<ResponsiveImage
+  @src={{responsive-image-fastly
+    'path/to/uploaded/image.jpg'
+    formats=(array 'webp' 'avif')
+  }}
+/>
+```
+
+```ts [Lit]
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { fastly } from '@responsive-image/cdn';
+import '@responsive-image/wc';
+
+@customElement('my-app')
+export class MyApp extends LitElement {
+  render() {
+    return html`<responsive-image
+      .src=${fastly('path/to/uploaded/image.jpg', {
+        formats: ['webp', 'avif'],
+      })}
+    ></responsive-image>`;
+  }
+}
+```
+
+```tsx [Solid]
+import { ResponsiveImage } from '@responsive-image/solid';
+import { fastly } from '@responsive-image/cdn';
+
+export default function MyApp() {
+  return (
+    <ResponsiveImage
+      src={fastly('path/to/uploaded/image.jpg', {
+        formats: ['webp', 'avif'],
+      })}
+    />
+  );
+}
+```
+
+```svelte [Svelte]
+<script>
+  import { ResponsiveImage } from '@responsive-image/svelte';
+  import { fastly } from '@responsive-image/cdn';
+</script>
+
+<ResponsiveImage
+  src={fastly('path/to/uploaded/image.jpg', {
+    formats: ['webp', 'avif'],
+  })}
+/>
+```
+
+:::
+
+:::info
+
+See the Fastify reference documentation for a [list of supported formats](https://www.fastly.com/documentation/reference/io/format/).
+
+`avif` requires you pay for [Fastly IO Professional](https://docs.fastly.com/en/guides/about-fastly-image-optimizer#before-you-begin).
+
+:::

--- a/apps/docs/src/cdn/fastly.md
+++ b/apps/docs/src/cdn/fastly.md
@@ -37,10 +37,10 @@ setConfig('cdn', {
 
 :::info
 
-By default `fastly` is configured to use the `auto` format.
-This uses [content negotiation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Content_negotiation)
-to use the optimal image format for any given browser.
-You can change this behavior with the `defaultFormats` configuration.
+By default `fastly` is configured to only use the `webp` format since `avif`
+requires a higher cost tier of Fastly IO.
+You can change which formats get used by default by passing `defaultFormats`
+next to `domain` in this configuration.
 
 :::
 

--- a/apps/docs/src/cdn/index.md
+++ b/apps/docs/src/cdn/index.md
@@ -1,11 +1,12 @@
 # Image CDNs
 
-This library supports multiple image CDNs to render [remote images]() with the image component.
+This library supports multiple image CDNs to render [remote images](../usage/remote-images.md) with the image component.
 
 With image CDNs the image processing is offloaded to the Cloud. This allows for _dynamic_ image processing, in cases where your images are not available at build-time. For example you could have an API endpoint (that hydrates a client-side model) refer to a raw (large, unprocessed) image, and use an image CDN as a proxy to scale, optimize and deliver that image as needed, at _runtime_.
 
 The following image CDNs are supported by the `@responsive-image/cdn` package out of the box:
 
 - [Cloudinary](./cloudinary.md)
+- [Fastly](./fastly.md)
 - [Imgix](./imgix.md)
 - [Netlify](./netlify.md)

--- a/apps/ember-test-app/app/app.ts
+++ b/apps/ember-test-app/app/app.ts
@@ -15,6 +15,9 @@ setConfig<Config>('cdn', {
   cloudinary: {
     cloudName: 'responsive-image',
   },
+  fastly: {
+    domain: 'www.fastly.io',
+  },
   imgix: {
     domain: 'responsive-image.imgix.net',
   },

--- a/apps/ember-test-app/app/templates/fastly.hbs
+++ b/apps/ember-test-app/app/templates/fastly.hbs
@@ -1,0 +1,4 @@
+<ResponsiveImage
+  @src={{responsive-image-fastly "image.webp" aspectRatio=2}}
+  data-test-image
+/>

--- a/apps/ember-test-app/tests/integration/helpers/responsive-image-fastly-test.gts
+++ b/apps/ember-test-app/tests/integration/helpers/responsive-image-fastly-test.gts
@@ -1,0 +1,33 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import responsiveImageFastly from '@responsive-image/ember/helpers/responsive-image-fastly';
+import type { ImageData } from '@responsive-image/ember';
+
+module('Integration | Helper | responsive-image-fastly', function (hooks) {
+  setupRenderingTest(hooks);
+
+  let data: ImageData | undefined;
+  const dump = (argument: ImageData) => {
+    data = argument;
+  };
+
+  test('it supports default image types', async function (assert) {
+    await render(
+      <template>{{dump (responsiveImageFastly "image.webp")}}</template>,
+    );
+
+    assert.deepEqual(data?.imageTypes, ['auto']);
+  });
+
+  test('it returns correct upload image URLs', async function (assert) {
+    await render(
+      <template>{{dump (responsiveImageFastly "image.webp")}}</template>,
+    );
+
+    assert.strictEqual(
+      data?.imageUrlFor(100, 'auto'),
+      'https://www.fastly.io/image.webp?format=auto&width=100',
+    );
+  });
+});

--- a/apps/ember-test-app/tests/integration/helpers/responsive-image-fastly-test.gts
+++ b/apps/ember-test-app/tests/integration/helpers/responsive-image-fastly-test.gts
@@ -17,7 +17,7 @@ module('Integration | Helper | responsive-image-fastly', function (hooks) {
       <template>{{dump (responsiveImageFastly "image.webp")}}</template>,
     );
 
-    assert.deepEqual(data?.imageTypes, ['auto']);
+    assert.deepEqual(data?.imageTypes, ['webp']);
   });
 
   test('it returns correct upload image URLs', async function (assert) {
@@ -26,8 +26,8 @@ module('Integration | Helper | responsive-image-fastly', function (hooks) {
     );
 
     assert.strictEqual(
-      data?.imageUrlFor(100, 'auto'),
-      'https://www.fastly.io/image.webp?format=auto&width=100',
+      data?.imageUrlFor(100, 'avif'),
+      'https://www.fastly.io/image.webp?format=avif&width=100',
     );
   });
 });

--- a/apps/ember-vite/app/app.js
+++ b/apps/ember-vite/app/app.js
@@ -15,6 +15,9 @@ setConfig('cdn', {
   cloudinary: {
     cloudName: 'responsive-image',
   },
+  fastly: {
+    domain: 'www.fastly.io',
+  },
   imgix: {
     domain: 'responsive-image.imgix.net',
   },

--- a/apps/ember-vite/app/templates/index.hbs
+++ b/apps/ember-vite/app/templates/index.hbs
@@ -20,6 +20,10 @@
   data-test-cloudinary-image
 />
 
+<h2>Fastly</h2>
+
+<ResponsiveImage @src={{responsive-image-fastly "image.webp" aspectRatio=2}} />
+
 <h2>imgix</h2>
 
 <ResponsiveImage

--- a/apps/ember-webpack/app/app.ts
+++ b/apps/ember-webpack/app/app.ts
@@ -15,6 +15,9 @@ setConfig<Config>('cdn', {
   cloudinary: {
     cloudName: 'responsive-image',
   },
+  fastly: {
+    domain: 'www.fastly.io',
+  },
   imgix: {
     domain: 'responsive-image.imgix.net',
   },

--- a/apps/ember-webpack/app/templates/index.hbs
+++ b/apps/ember-webpack/app/templates/index.hbs
@@ -20,6 +20,10 @@
   data-test-cloudinary-image
 />
 
+<h2>Fastly</h2>
+
+<ResponsiveImage @src={{responsive-image-fastly "image.webp" aspectRatio=2}} />
+
 <h2>imgix</h2>
 
 <ResponsiveImage

--- a/apps/solid-start/src/app.tsx
+++ b/apps/solid-start/src/app.tsx
@@ -11,6 +11,9 @@ setConfig<Config>('cdn', {
   cloudinary: {
     cloudName: 'responsive-image',
   },
+  fastly: {
+    domain: 'www.fastly.io',
+  },
   imgix: {
     domain: 'responsive-image.imgix.net',
   },

--- a/apps/solid-start/src/routes/index.tsx
+++ b/apps/solid-start/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import { cloudinary, imgix, netlify } from '@responsive-image/cdn';
+import { cloudinary, fastly, imgix, netlify } from '@responsive-image/cdn';
 import { ResponsiveImage } from '@responsive-image/solid';
 import image from '../images/aurora.jpg?responsive';
 import imageLqipColor from '../images/aurora.jpg?lqip=color&responsive';
@@ -22,6 +22,13 @@ export default function Home() {
           aspectRatio: 1.4971927636,
         })}
         data-test-cloudinary-image
+      />
+      <h2>Fastly</h2>
+      <ResponsiveImage
+        src={fastly('image.webp', {
+          aspectRatio: 2,
+        })}
+        data-test-fastly-image
       />
       <h2>imgix</h2>
       <ResponsiveImage

--- a/apps/svelte-kit/src/routes/+page.svelte
+++ b/apps/svelte-kit/src/routes/+page.svelte
@@ -2,6 +2,7 @@
   import { ResponsiveImage } from '@responsive-image/svelte';
   import {
     cloudinary,
+    fastly,
     imgix,
     netlify,
     type Config,
@@ -18,6 +19,9 @@
   setConfig<Config>('cdn', {
     cloudinary: {
       cloudName: 'responsive-image',
+    },
+    fastly: {
+      domain: 'www.fastly.io',
     },
     imgix: {
       domain: 'responsive-image.imgix.net',
@@ -41,6 +45,11 @@
     aspectRatio: 1.4971927636,
   })}
   data-test-cloudinary-image
+/>
+<h2>Fastly</h2>
+<ResponsiveImage
+  src={fastly('image.webp', { aspectRatio: 2 })}
+  data-test-fastly-image
 />
 <h2>imgix</h2>
 <ResponsiveImage

--- a/apps/wc-lit/src/app.ts
+++ b/apps/wc-lit/src/app.ts
@@ -1,6 +1,6 @@
 import { LitElement, css, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { cloudinary, imgix, netlify } from '@responsive-image/cdn';
+import { cloudinary, fastly, imgix, netlify } from '@responsive-image/cdn';
 import { setConfig } from '@responsive-image/core';
 import '@responsive-image/wc';
 import image from './images/aurora.jpg?responsive';
@@ -16,6 +16,9 @@ import type { Config } from '@responsive-image/cdn';
 setConfig<Config>('cdn', {
   cloudinary: {
     cloudName: 'responsive-image',
+  },
+  fastly: {
+    domain: 'www.fastly.io',
   },
   imgix: {
     domain: 'responsive-image.imgix.net',
@@ -43,6 +46,13 @@ export class MyApp extends LitElement {
       <responsive-image
         .src=${cloudinary('aurora-original_w0sk6h', { aspectRatio: 1.4971927636 })}
         data-test-cloudinary-image
+      ></responsive-image>
+
+      <h2>Fastly</h2>
+
+      <responsive-image
+        .src=${fastly('image.webp', { aspectRatio: 2 })}
+        data-test-fastly-image
       ></responsive-image>
 
       <h2>imgix</h2>

--- a/packages/cdn/src/fastly.ts
+++ b/packages/cdn/src/fastly.ts
@@ -1,0 +1,271 @@
+import { assert, getConfig } from '@responsive-image/core';
+
+import type { Config, CoreOptions } from './types';
+import type { ImageData, ImageType } from '@responsive-image/core';
+
+export interface FastlyConfig {
+  /**
+   * By default `fastly` uses the `auto` format to let
+   * Fastly determine the optimal format based on
+   * [content negotiation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Content_negotiation).
+   *
+   * Use this to set a different list of default formats.
+   */
+  defaultFormats?: FastlyImageFormats[];
+  domain?: string;
+}
+
+type FastlyImageFormats =
+  | 'auto'
+  | 'avif'
+  | 'bjpg'
+  | 'bjpeg'
+  | 'gif'
+  | 'jpg'
+  | 'jpeg'
+  | 'jxl'
+  | 'jpegxl'
+  | 'mp4'
+  | 'pjpg'
+  | 'pjpeg'
+  | 'pjxl'
+  | 'pjpegxl'
+  | 'png'
+  | 'png8'
+  | 'webp'
+  | 'webpll'
+  | 'webply';
+
+export interface FastlyOptions extends Omit<CoreOptions, 'formats'> {
+  /**
+   * Enables optimizations based on [content negotiation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation).
+   * @see https://www.fastly.com/documentation/reference/io/auto/
+   */
+  auto?: 'avif' | 'webp';
+  /**
+   * Sets the background color of the image when adding padding
+   * or for transparent images.
+   * @see https://www.fastly.com/documentation/reference/io/bg-color/
+   */
+  bgColor?: string | number;
+  /**
+   * Applies a Gaussian blur filter to the image.
+   * @see https://www.fastly.com/documentation/reference/io/blur/
+   */
+  blur?: string | number;
+  /**
+   * Adjust the amount of perceived light an image radiates or reflects.
+   * @see https://www.fastly.com/documentation/reference/io/brightness/
+   */
+  brightness?: number;
+  /**
+   * Sets the size of the image canvas, without changing the size of the image itself, which has the effect of adding space around the image.
+   * @see https://www.fastly.com/documentation/reference/io/canvas/
+   * @example '320,240'
+   */
+  canvas?: string;
+  /**
+   * Adjust the difference between the darkest and lightest tones in an image.
+   * @see https://www.fastly.com/documentation/reference/io/contrast/
+   */
+  contrast?: number;
+  /**
+   * Removes pixels from an image.
+   * @see https://www.fastly.com/documentation/reference/io/crop/
+   * @example '320,240'
+   * @example '16:9'
+   */
+  crop?: string;
+  /**
+   * Turn off features that are enabled by default.
+   *
+   * Note that `upscale` is disabled by default for Fastly IO services
+   * enabled after April 2018.
+   *
+   * @see https://www.fastly.com/documentation/reference/io/disable/
+   * @see https://www.fastly.com/documentation/reference/io/enable/
+   */
+  disable?: 'upscale';
+  /**
+   * Device pixel ratio.
+   *
+   * Image dimensions in pixel values get multiplied by this ratio
+   * in the final result.
+   *
+   * Given a width of 200px and a dpr of 2, the end result is
+   * an image resized to 400px (equivalent to 200 [CSS pixels](https://developer.mozilla.org/en-US/docs/Glossary/CSS_pixel)
+   * given a device pixel ratio of 2).
+   *
+   * @see https://www.fastly.com/documentation/reference/io/dpr/
+   */
+  dpr?: number;
+  /**
+   * Turn on features that are disabled by default.
+   *
+   * @see https://www.fastly.com/documentation/reference/io/enable/
+   * @see https://www.fastly.com/documentation/reference/io/disable/
+   */
+  enabled?: 'upscale';
+  /**
+   * Controls how the image will be constrained within the provided size
+   * in order to maintain correct proportions.
+   *
+   * @see https://www.fastly.com/documentation/reference/io/fit/
+   */
+  fit?: 'bounds' | 'cover' | 'crop';
+  /**
+   * Specifies the desired output encoding for the image.
+   *
+   * @see https://www.fastly.com/documentation/reference/io/format/
+   */
+  formats?: FastlyImageFormats[];
+  /**
+   * Extracts the first frame from an animated image sequence (gif).
+   *
+   * @see https://www.fastly.com/documentation/reference/io/frame/
+   */
+  frame?: 1;
+  /**
+   * The desired height of the output image.
+   *
+   * @see https://www.fastly.com/documentation/reference/io/height/
+   */
+  height?: string | number;
+  /**
+   * When converting GIFs to MP4 and when using `profile`,
+   * the level parameter specifies contraints for the decoder
+   * performance of a profile.
+   *
+   * @see https://www.fastly.com/documentation/reference/io/level/
+   */
+  level?: string | number;
+  /**
+   * By default, Fastly IO removes all metadata from images.
+   * This parameter allows you to keep certain metadata intact.
+   *
+   * @see https://www.fastly.com/documentation/reference/io/metadata/
+   */
+  metadata?: 'copyright';
+  /**
+   * Determine the level of compression.
+   *
+   * @see https://www.fastly.com/documentation/reference/io/optimize/
+   */
+  optimize?: 'low' | 'medium' | 'high';
+  /**
+   * Change the image orientation.
+   *
+   * @see https://www.fastly.com/documentation/reference/io/orient/
+   */
+  orient?: 'r' | 'l' | 'h' | 'v' | 'hv' | 'vh' | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+  /**
+   * Add pixels to the edge of an image.
+   *
+   * @see https://www.fastly.com/documentation/reference/io/pad/
+   */
+  pad?: string | number;
+  /**
+   * Identical to `crop` except `precrop` is done before any other transformations.
+   *
+   * @see https://www.fastly.com/documentation/reference/io/precrop/
+   * @see https://www.fastly.com/documentation/reference/io/crop/
+   */
+  precrop?: string;
+  /**
+   * When converting animated GIFs to MP4 and used with `level`,
+   * the `profile` parameter controls what features the video encoder
+   * can use.
+   *
+   * @see https://www.fastly.com/documentation/reference/io/profile/
+   */
+  profile?: 'baseline' | 'main' | 'high';
+  /**
+   * Enables control over the resizing filter used when generating
+   * images with a higher or lower pixel value than the original.
+   *
+   * @see https://www.fastly.com/documentation/reference/io/resize-filter/
+   */
+  resizeFilter?:
+    | 'nearest'
+    | 'bilinear'
+    | 'linear'
+    | 'bicubic'
+    | 'cubic'
+    | 'lanczos2'
+    | 'lanczos3'
+    | 'lanczos';
+  /**
+   * Adjust the intensity of colors in an image.
+   *
+   * @see https://www.fastly.com/documentation/reference/io/saturation/
+   */
+  saturation?: number;
+  /**
+   * Adjust the definition of the edges of objects in an image.
+   *
+   * @see https://www.fastly.com/documentation/reference/io/sharpen/
+   */
+  sharpen?: string;
+  /**
+   * Remove pixels from the edge of an image.
+   *
+   * @see https://www.fastly.com/documentation/reference/io/trim/
+   */
+  trim?: string;
+  /**
+   * Identify a rectangular border based on a given or detected color,
+   * and remove that border from the edges of an image.
+   *
+   * Only works on non-GIF input images.
+   *
+   * @see https://www.fastly.com/documentation/reference/io/trim-color/
+   */
+  trimColor?: string;
+}
+
+function normalizeSrc(src: string): string {
+  return src[0] === '/' ? src.slice(1) : src;
+}
+
+export function fastly(image: string, options: FastlyOptions = {}): ImageData {
+  const config = getConfig<Config>('cdn')?.fastly || {};
+  const domain = config.domain;
+  const defaultFormats = config.defaultFormats ?? ['auto'];
+  assert(
+    'domain must be set for the fastly provider!',
+    typeof domain === 'string',
+  );
+
+  const imageData: ImageData = {
+    imageTypes: options.formats ?? defaultFormats,
+    imageUrlFor(width: number, type: ImageType = 'auto') {
+      const url = new URL(`https://${domain}/${normalizeSrc(image)}`);
+      const searchParams = url.searchParams;
+
+      searchParams.set('format', type);
+      searchParams.set('width', String(width));
+
+      for (const [key, value] of Object.entries(options)) {
+        if (key === 'aspectRatio') {
+          continue;
+        } else if (key === 'bgColor') {
+          searchParams.set('bg-color', value);
+        } else if (key === 'resizeFilter') {
+          searchParams.set('resize-filter', value);
+        } else if (key === 'trimColor') {
+          searchParams.set('trim-color', value);
+        } else {
+          searchParams.set(key, String(value));
+        }
+      }
+
+      return url.toString();
+    },
+  };
+
+  if (options.aspectRatio) {
+    imageData.aspectRatio = options.aspectRatio;
+  }
+
+  return imageData;
+}

--- a/packages/cdn/src/fastly.ts
+++ b/packages/cdn/src/fastly.ts
@@ -8,31 +8,11 @@ export interface FastlyConfig {
    * By default `fastly` uses the `webp` format.
    * Use this to set a different list of default formats.
    */
-  defaultFormats?: FastlyImageFormats[];
+  defaultFormats?: ImageType[];
   domain?: string;
 }
 
-type FastlyImageFormats =
-  | 'avif'
-  | 'bjpg'
-  | 'bjpeg'
-  | 'gif'
-  | 'jpg'
-  | 'jpeg'
-  | 'jxl'
-  | 'jpegxl'
-  | 'mp4'
-  | 'pjpg'
-  | 'pjpeg'
-  | 'pjxl'
-  | 'pjpegxl'
-  | 'png'
-  | 'png8'
-  | 'webp'
-  | 'webpll'
-  | 'webply';
-
-export interface FastlyOptions extends Omit<CoreOptions, 'formats'> {
+export interface FastlyOptions extends CoreOptions {
   /**
    * Sets the background color of the image when adding padding
    * or for transparent images.
@@ -109,7 +89,7 @@ export interface FastlyOptions extends Omit<CoreOptions, 'formats'> {
    *
    * @see https://www.fastly.com/documentation/reference/io/format/
    */
-  formats?: FastlyImageFormats[];
+  formats?: ImageType[];
   /**
    * Extracts the first frame from an animated image sequence (gif).
    *
@@ -226,7 +206,7 @@ function kebabCase(camelCase: string): string {
 }
 
 export function fastly(image: string, options: FastlyOptions = {}): ImageData {
-  const config = getConfig<Config>('cdn')?.fastly || {};
+  const config = getConfig<Config>('cdn')?.fastly ?? {};
   const domain = config.domain;
   assert(
     'domain must be set for the fastly provider!',
@@ -237,9 +217,7 @@ export function fastly(image: string, options: FastlyOptions = {}): ImageData {
   const defaultFormats = config.defaultFormats ?? ['webp'];
 
   const imageData: ImageData = {
-    // The components handle more formats than ImageType,
-    // though with a priority of 0
-    imageTypes: (options.formats ?? defaultFormats) as ImageType[],
+    imageTypes: options.formats ?? defaultFormats,
     imageUrlFor(width: number, type: ImageType = 'jpeg') {
       const url = new URL(`https://${domain}/${normalizeSrc(image)}`);
       const searchParams = url.searchParams;

--- a/packages/cdn/src/fastly.ts
+++ b/packages/cdn/src/fastly.ts
@@ -5,10 +5,7 @@ import type { ImageData, ImageType } from '@responsive-image/core';
 
 export interface FastlyConfig {
   /**
-   * By default `fastly` uses the `auto` format to let
-   * Fastly determine the optimal format based on
-   * [content negotiation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Content_negotiation).
-   *
+   * By default `fastly` uses the `webp` format.
    * Use this to set a different list of default formats.
    */
   defaultFormats?: FastlyImageFormats[];

--- a/packages/cdn/src/index.ts
+++ b/packages/cdn/src/index.ts
@@ -1,4 +1,5 @@
 export * from './cloudinary.ts';
+export * from './fastly.ts';
 export * from './imgix.ts';
 export * from './netlify.ts';
 export * from './types.ts';

--- a/packages/cdn/src/types.ts
+++ b/packages/cdn/src/types.ts
@@ -1,10 +1,12 @@
 import type { CloudinaryConfig } from './cloudinary';
+import type { FastlyConfig } from './fastly';
 import type { ImgixConfig } from './imgix';
 import type { NetlifyConfig } from './netlify';
 import type { ImageType } from '@responsive-image/core';
 
 export interface Config {
   imgix?: ImgixConfig;
+  fastly?: FastlyConfig;
   cloudinary?: CloudinaryConfig;
   netlify?: NetlifyConfig;
 }

--- a/packages/cdn/tests/fastly.test.ts
+++ b/packages/cdn/tests/fastly.test.ts
@@ -10,13 +10,13 @@ describe('fastly', function () {
     setConfig<Config>('cdn', { fastly: { domain: 'image.mydomain.com' } });
   });
 
-  test('it uses the auto format by default', function () {
+  test('it uses the webp format by default', function () {
     const result = fastly('foo/bar.jpg');
 
-    expect(result?.imageTypes).toEqual(['auto']);
+    expect(result?.imageTypes).toEqual(['webp']);
   });
 
-  test('can set custom default formats', function () {
+  test('can set custom default formats (f. ex. add avif)', function () {
     setConfig<Config>('cdn', {
       fastly: {
         domain: 'image.mydomain.com',

--- a/packages/cdn/tests/fastly.test.ts
+++ b/packages/cdn/tests/fastly.test.ts
@@ -1,0 +1,67 @@
+import { setConfig } from '@responsive-image/core';
+import { beforeAll, describe, expect, test } from 'vitest';
+
+import { fastly } from '../src';
+
+import type { Config } from '../src';
+
+describe('fastly', function () {
+  beforeAll(() => {
+    setConfig<Config>('cdn', { fastly: { domain: 'image.mydomain.com' } });
+  });
+
+  test('it uses the auto format by default', function () {
+    const result = fastly('foo/bar.jpg');
+
+    expect(result?.imageTypes).toEqual(['auto']);
+  });
+
+  test('can set custom default formats', function () {
+    setConfig<Config>('cdn', {
+      fastly: {
+        domain: 'image.mydomain.com',
+        defaultFormats: ['webp', 'avif'],
+      },
+    });
+
+    const result = fastly('foo/bar.jpg');
+
+    expect(result?.imageTypes).toEqual(['webp', 'avif']);
+  });
+
+  test('it supports custom image types', function () {
+    const result = fastly('foo/bar.jpg', {
+      formats: ['jpeg', 'webp'],
+    });
+
+    expect(result?.imageTypes).toEqual(['jpeg', 'webp']);
+  });
+
+  test('it returns custom params', function () {
+    const result = fastly('foo/bar.jpg', {
+      trimColor: 'auto',
+    });
+
+    expect(result.imageUrlFor(100, 'jpeg')).toBe(
+      'https://image.mydomain.com/foo/bar.jpg?format=jpeg&width=100&trim-color=auto',
+    );
+  });
+
+  test('it supports custom quality setting', function () {
+    const result = fastly('foo/bar.jpg', {
+      quality: 50,
+    });
+
+    expect(result.imageUrlFor(100, 'jpeg')).toBe(
+      'https://image.mydomain.com/foo/bar.jpg?format=jpeg&width=100&quality=50',
+    );
+  });
+
+  test('it supports custom aspectRatio', function () {
+    const result = fastly('foo/bar.jpg', {
+      aspectRatio: 2,
+    });
+
+    expect(result.aspectRatio).toBe(2);
+  });
+});

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,4 @@
-export type ImageType = 'png' | 'jpeg' | 'webp' | 'avif';
+export type ImageType = 'png' | 'jpeg' | 'webp' | 'avif' | 'auto' | string;
 
 export type NonFunction =
   | string

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,4 @@
-export type ImageType = 'png' | 'jpeg' | 'webp' | 'avif' | 'auto' | string;
+export type ImageType = 'png' | 'jpeg' | 'webp' | 'avif';
 
 export type NonFunction =
   | string

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -87,6 +87,7 @@
     "app-js": {
       "./components/responsive-image.js": "./dist/_app_/components/responsive-image.js",
       "./helpers/responsive-image-cloudinary.js": "./dist/_app_/helpers/responsive-image-cloudinary.js",
+      "./helpers/responsive-image-fastly.js": "./dist/_app_/helpers/responsive-image-fastly.js",
       "./helpers/responsive-image-imgix.js": "./dist/_app_/helpers/responsive-image-imgix.js",
       "./helpers/responsive-image-netlify.js": "./dist/_app_/helpers/responsive-image-netlify.js",
       "./helpers/responsive-image-resolve.js": "./dist/_app_/helpers/responsive-image-resolve.js"

--- a/packages/ember/src/helpers/responsive-image-fastly.ts
+++ b/packages/ember/src/helpers/responsive-image-fastly.ts
@@ -1,0 +1,1 @@
+export { fastly as default } from '@responsive-image/cdn';

--- a/packages/ember/src/template-registry.ts
+++ b/packages/ember/src/template-registry.ts
@@ -1,5 +1,6 @@
 import type ResponsiveImageComponent from './components/responsive-image.gts';
 import type CloudinaryProvider from './helpers/responsive-image-cloudinary';
+import type FastlyProvider from './helpers/responsive-image-fastly';
 import type ImgixProvider from './helpers/responsive-image-imgix.ts';
 import type NetlifyProvider from './helpers/responsive-image-netlify';
 import type ResponsiveImageResolve from './helpers/responsive-image-resolve.ts';
@@ -8,6 +9,7 @@ export default interface Registry {
   ResponsiveImage: typeof ResponsiveImageComponent;
   'responsive-image-resolve': typeof ResponsiveImageResolve;
   'responsive-image-cloudinary': typeof CloudinaryProvider;
+  'responsive-image-fastly': typeof FastlyProvider;
   'responsive-image-netlify': typeof NetlifyProvider;
   'responsive-image-imgix': typeof ImgixProvider;
 }


### PR DESCRIPTION
Hey there 👋 Sorry for opening such a big PR out of the blue, hope it's OK. Adding a new CDN was a bigger operation than we first assumed 😅

tl;dr - add [Fastly Image Optimizer](https://www.fastly.com/documentation/reference/io/) (IO) as a supported CDN

Of note:

- There's no free tier that we could find for Fastly IO, but they have a demo image that we've used here for the integration tests.
- We add `'auto' | string` to `ImageType` since we should default to using [`auto`](https://www.fastly.com/documentation/reference/io/format/#about-the-auto-value) and let Fastly decide the optimal format based on the browser. `string` because Fastify supports a bunch of formats users could theoretically want to use. We figure defaulting to a [priority 0](https://github.com/simonihmig/responsive-image/blob/8c2542a28dc0954ef5d5608441dddedb484e12ac/packages/wc/src/responsive-image.ts#L136) in components is fine.
- Otherwise it works much like `imgix`, though with different options and output URLs.

Another thing we noticed is that in the test apps with server-side generation the size always [gets set to 320px](https://github.com/simonihmig/responsive-image/blob/8c2542a28dc0954ef5d5608441dddedb484e12ac/packages/core/src/env.ts#L5) for the remote image tests, but for some reason they visually look OK for the other CDNs 🤷 Inspecting the actual query the size should be `320px`, but maybe they have a minimum size limit or something like that. So even though the Fastly image is low quality the component test technically works as expected.