### PR TITLE
Support having CDNs decide the image format

### DIFF
--- a/.changeset/beige-needles-serve.md
+++ b/.changeset/beige-needles-serve.md
@@ -1,0 +1,13 @@
+---
+'@responsive-image/core': major
+---
+
+ImageData.imageTypes can now be the string 'auto'
+
+CDNs often have a feature to automatically choose the
+optimal format based on the visiting browser. This type
+change is made to support using such features in the
+`cdn` package.
+
+Where you assume `imageTypes` is an array of strings,
+update to also support the `imageTypes: 'auto'` case.

--- a/.changeset/floppy-masks-run.md
+++ b/.changeset/floppy-masks-run.md
@@ -1,0 +1,9 @@
+---
+'@responsive-image/svelte': minor
+'@responsive-image/ember': minor
+'@responsive-image/react': minor
+'@responsive-image/solid': minor
+'@responsive-image/wc': minor
+---
+
+Add support for the 'auto' imageType

--- a/.changeset/petite-deer-camp.md
+++ b/.changeset/petite-deer-camp.md
@@ -1,0 +1,14 @@
+---
+'@responsive-image/cdn': major
+---
+
+The default imageTypes changed to 'auto'
+
+The default imageTypes changed from an array
+of image formats to the string 'auto' in order
+to have the CDN backend decide the format.
+Image components that assume imageTypes is
+an array need to be updated to accept the
+string 'auto'. In such cases the component
+should render only an `<img>` tag with
+a srcset attribute.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Supports basic PNG and JPEG formats, as well as next-gen WebP and AVIF, for incr
 Fast image processing of local images with a selection of optionally applyable filters and effects, using the popular sharp library.
 
 🌍 **Image CDNs**:
-Besides processing of local images, it also supports integrating remote images from image CDNs like Cloudinary or imgix using a versatile image provider abstraction
+Besides processing of local images, it also supports integrating remote images from image CDNs like Cloudinary or imgix using a versatile image provider abstraction.
 
 ⏳ **Image Placeholders**:
 Supports Low Quality Image Placeholders (LQIP) techniques to show a preview while loading, using different strategies like a blurry low-res image, BlurHash or a simple dominant color.

--- a/apps/docs/src/cdn/cloudinary.md
+++ b/apps/docs/src/cdn/cloudinary.md
@@ -1,3 +1,7 @@
+---
+outline: [2, 3]
+---
+
 # Cloudinary
 
 The image processing capabilities of the [Cloudinary](https://cloudinary.com) image CDN are supported by a helper function provided to you by this library.
@@ -384,8 +388,9 @@ export default function MyApp() {
 
 ### Image formats
 
-By default, modern image formats (webp, avif) are referenced in the generated `<source>` tags.
-You can tweak that using the `formats` argument:
+By default the component uses the [automatic image format selection](https://cloudinary.com/documentation/image_optimization#automatic_format_selection_f_auto) in Cloudinary.
+
+If you want a `picture` tag with one or more specific formats as `source` tags you can specify them using the `formats` argument:
 
 ::: code-group
 

--- a/apps/docs/src/cdn/fastly.md
+++ b/apps/docs/src/cdn/fastly.md
@@ -1,3 +1,7 @@
+---
+outline: [2, 3]
+---
+
 # Fastly
 
 The [Fastly Image Optimizer](https://www.fastly.com/documentation/reference/io/) (IO)
@@ -391,8 +395,9 @@ export default function MyApp() {
 
 ### Image formats
 
-By default, a modern image format (webp) is referenced in the generated `<source>` tags.
-You can tweak that using the `formats` argument:
+By default the component uses the [automatic image format selection](https://www.fastly.com/documentation/reference/io/format/) in Fastly.
+
+If you want a `picture` tag with one or more specific formats as `source` tags you can specify them using the `formats` argument:
 
 ::: code-group
 

--- a/apps/docs/src/cdn/imgix.md
+++ b/apps/docs/src/cdn/imgix.md
@@ -1,3 +1,7 @@
+---
+outline: [2, 3]
+---
+
 # imgix
 
 The image processing capabilities of the [imgix](https://imgix.com) image CDN are supported by a helper function provided to you by this library.
@@ -379,8 +383,9 @@ export default function MyApp() {
 
 ### Image formats
 
-By default, modern image formats (webp, avif) are referenced in the generated `<source>` tags.
-You can tweak that using the `formats` argument:
+By default the component uses the [automatic image format selection](https://docs.imgix.com/en-US/apis/rendering/automatic#format) in Imgix.
+
+If you want a `picture` tag with one or more specific formats as `source` tags you can specify them using the `formats` argument:
 
 ::: code-group
 

--- a/apps/docs/src/cdn/netlify.md
+++ b/apps/docs/src/cdn/netlify.md
@@ -1,3 +1,7 @@
+---
+outline: [2, 3]
+---
+
 # Netlify
 
 The image processing capabilities of the [Netlify Image CDN](https://docs.netlify.com/image-cdn/overview/) are supported by a helper function provided to you by this library.
@@ -283,8 +287,9 @@ export default function MyApp() {
 
 ### Image formats
 
-By default, modern image formats (webp, avif) are referenced in the generated `<source>` tags.
-You can tweak that using the `formats` argument:
+By default the component uses the [automatic image format selection](https://docs.netlify.com/image-cdn/overview/#format) in Netlify.
+
+If you want a `picture` tag with one or more specific formats as `source` tags you can specify them using the `formats` argument:
 
 ::: code-group
 

--- a/apps/docs/src/index.md
+++ b/apps/docs/src/index.md
@@ -25,7 +25,7 @@ features:
   - title: Local image processing
     details: Fast processing of local images with a selection of optionally applyable filters and effects. Generates responsive images at different sizes, using the popular sharp library.
   - title: Image CDNs
-    details: Besides processing of local images, it also supports integrating remote images from <b>image CDNs</b> like Cloudinary or imgix using a versatile image provider abstraction
+    details: Besides processing of local images, it also supports integrating remote images from <b>image CDNs</b> like Cloudinary or imgix using a versatile image provider abstraction.
   - title: Image Placeholders
     details: Supports Low Quality Image Placeholders (LQIP) to show a preview while loading, using a simple dominant color, a blurred low-res image or advanced ThumbHash placeholders.
   - title: Layout modes

--- a/apps/docs/src/usage/component.md
+++ b/apps/docs/src/usage/component.md
@@ -97,7 +97,7 @@ This will render an `<img>` element wrapped in `<picture>` referencing all the r
 ```
 
 > [!NOTE]
-> Actually it will likely have more image sizes, but this has been reduced here for readability.
+> Actually it will likely have more image sizes, but this has been reduced here for readability. When using an image CDN by default the component will render just an `img` with a `srcset` attribute and let the CDN choose the optimal format.
 
 ## Layout modes
 

--- a/apps/ember-test-app/app/router.js
+++ b/apps/ember-test-app/app/router.js
@@ -11,4 +11,5 @@ Router.map(function () {
   this.route('cloudinary');
   this.route('imgix');
   this.route('netlify');
+  this.route('fastly');
 });

--- a/apps/ember-test-app/tests/fastboot/fastly-test.js
+++ b/apps/ember-test-app/tests/fastboot/fastly-test.js
@@ -4,18 +4,18 @@ import {
   visit /* mockServer */,
 } from 'ember-cli-fastboot-testing/test-support';
 
-module('FastBoot | Cloudinary', function (hooks) {
+module('FastBoot | Fastly', function (hooks) {
   setup(hooks);
 
   test('it renders an image', async function (assert) {
-    await visit('/cloudinary');
+    await visit('/fastly');
 
     assert.dom('img[data-test-image]').exists();
     assert
       .dom('img[data-test-image]')
       .hasAttribute(
         'src',
-        'https://res.cloudinary.com/responsive-image/image/upload/w_320,c_limit,q_auto/f_auto/aurora-original_w0sk6h',
+        'https://www.fastly.io/image.webp?format=auto&width=320',
       );
   });
 });

--- a/apps/ember-test-app/tests/fastboot/imgix-test.js
+++ b/apps/ember-test-app/tests/fastboot/imgix-test.js
@@ -15,7 +15,7 @@ module('FastBoot | Imgix', function (hooks) {
       .dom('img[data-test-image]')
       .hasAttribute(
         'src',
-        'https://responsive-image.imgix.net/aurora-original.jpg?fm=jpg&w=320&fit=max',
+        'https://responsive-image.imgix.net/aurora-original.jpg?auto=format&w=320&fit=max',
       );
   });
 });

--- a/apps/ember-test-app/tests/fastboot/netlify-test.js
+++ b/apps/ember-test-app/tests/fastboot/netlify-test.js
@@ -15,7 +15,7 @@ module('FastBoot | Netlify', function (hooks) {
       .dom('img[data-test-image]')
       .hasAttribute(
         'src',
-        'https://responsive-image.dev/.netlify/images?url=aurora-original.jpg&w=320&fm=jpg',
+        'https://responsive-image.dev/.netlify/images?url=aurora-original.jpg&w=320',
       );
   });
 });

--- a/apps/ember-test-app/tests/integration/components/responsive-image-test.gts
+++ b/apps/ember-test-app/tests/integration/components/responsive-image-test.gts
@@ -495,4 +495,35 @@ module('Integration: Responsive Image Component', function (hooks) {
         );
     });
   });
+
+  module('auto format', () => {
+    const imageData: ImageData = {
+      imageTypes: 'auto',
+      imageUrlFor(width, type = 'jpeg') {
+        return `/provider/w${width}/image.webp?format=${type}`;
+      },
+      availableWidths: [50, 100, 640],
+      aspectRatio: 2,
+    };
+
+    test('it renders a srcset on the img tag', async function (this: RenderingTestContext, assert) {
+      await render(<template><ResponsiveImage @src={{imageData}} /></template>);
+
+      const imgEl = this.element.querySelector('img')!;
+
+      assert
+        .dom(imgEl)
+        .hasAttribute(
+          'srcset',
+          '/provider/w50/image.webp?format=auto 50w, /provider/w100/image.webp?format=auto 100w, /provider/w640/image.webp?format=auto 640w',
+        );
+    });
+
+    test('it omits the picture and source tags', async function (this: RenderingTestContext, assert) {
+      await render(<template><ResponsiveImage @src={{imageData}} /></template>);
+
+      assert.dom('picture').exists({ count: 0 });
+      assert.dom('source').exists({ count: 0 });
+    });
+  });
 });

--- a/apps/ember-test-app/tests/integration/components/responsive-image-test.gts
+++ b/apps/ember-test-app/tests/integration/components/responsive-image-test.gts
@@ -522,8 +522,8 @@ module('Integration: Responsive Image Component', function (hooks) {
     test('it omits the picture and source tags', async function (this: RenderingTestContext, assert) {
       await render(<template><ResponsiveImage @src={{imageData}} /></template>);
 
-      assert.dom('picture').exists({ count: 0 });
-      assert.dom('source').exists({ count: 0 });
+      assert.dom('picture').doesNotExist();
+      assert.dom('source').doesNotExist();
     });
   });
 });

--- a/apps/ember-test-app/tests/integration/helpers/responsive-image-cloudinary-test.gts
+++ b/apps/ember-test-app/tests/integration/helpers/responsive-image-cloudinary-test.gts
@@ -20,7 +20,7 @@ module('Integration | Helper | responsive-image-cloudinary', function (hooks) {
       </template>,
     );
 
-    assert.deepEqual(data?.imageTypes, ['webp', 'avif']);
+    assert.deepEqual(data?.imageTypes, 'auto');
   });
 
   test('it returns correct upload image URLs', async function (assert) {

--- a/apps/ember-test-app/tests/integration/helpers/responsive-image-fastly-test.gts
+++ b/apps/ember-test-app/tests/integration/helpers/responsive-image-fastly-test.gts
@@ -17,7 +17,7 @@ module('Integration | Helper | responsive-image-fastly', function (hooks) {
       <template>{{dump (responsiveImageFastly "image.webp")}}</template>,
     );
 
-    assert.deepEqual(data?.imageTypes, ['webp']);
+    assert.deepEqual(data?.imageTypes, 'auto');
   });
 
   test('it returns correct upload image URLs', async function (assert) {

--- a/apps/ember-test-app/tests/integration/helpers/responsive-image-imgix-test.gts
+++ b/apps/ember-test-app/tests/integration/helpers/responsive-image-imgix-test.gts
@@ -19,7 +19,7 @@ module('Integration | Helper | responsive-image-imgix', function (hooks) {
       </template>,
     );
 
-    assert.deepEqual(data?.imageTypes, ['webp', 'avif']);
+    assert.deepEqual(data?.imageTypes, 'auto');
   });
 
   test('it returns correct image URLs', async function (assert) {

--- a/apps/ember-test-app/tests/integration/helpers/responsive-image-netlify-test.gts
+++ b/apps/ember-test-app/tests/integration/helpers/responsive-image-netlify-test.gts
@@ -24,7 +24,7 @@ module('Integration | Helper | responsive-image-netlify', function (hooks) {
       <template>{{dump (responsiveImageNetlify "/foo/bar.jpg")}}</template>,
     );
 
-    assert.deepEqual(data?.imageTypes, ['webp', 'avif']);
+    assert.deepEqual(data?.imageTypes, 'auto');
   });
 
   test('it returns correct relative image URLs', async function (assert) {

--- a/packages/cdn/src/cloudinary.ts
+++ b/packages/cdn/src/cloudinary.ts
@@ -1,7 +1,7 @@
 import { assert, getConfig } from '@responsive-image/core';
 
 import type { Config, CoreOptions } from './types';
-import type { ImageType, ImageData } from '@responsive-image/core';
+import type { ImageData, ImageUrlForType } from '@responsive-image/core';
 
 export interface CloudinaryConfig {
   cloudName: string;
@@ -47,7 +47,7 @@ export function cloudinary(
 
   const imageData: ImageData = {
     imageTypes: options.formats ?? ['webp', 'avif'],
-    imageUrlFor(width: number, type: ImageType = 'jpeg'): string {
+    imageUrlFor(width: number, type: ImageUrlForType = 'jpeg'): string {
       const resizeParams: CloudinaryTransformation = {
         w: width,
         c: 'limit',
@@ -71,21 +71,23 @@ export function cloudinary(
           .join(','),
       );
 
-      if (options.auto === 'format') {
+      if (type === 'auto') {
         pathParameters.push('f_auto');
       }
 
       const params = pathParameters.join('/');
 
+      // Omit the extension when using auto for the upload delivery method
+      // https://cloudinary.com/documentation/transformation_reference#_lt_extension_gt
+      const extension =
+        deliveryType === 'upload' && type !== 'auto' ? '.' + type : '';
+
       return `https://res.cloudinary.com/${cloudName}/image/${deliveryType}/${params}/${imageId}${
-        deliveryType === 'upload' ? '.' + type : ''
+        extension
       }`;
     },
   };
 
-  if (options.auto) {
-    imageData.auto = options.auto;
-  }
   if (options.aspectRatio) {
     imageData.aspectRatio = options.aspectRatio;
   }

--- a/packages/cdn/src/cloudinary.ts
+++ b/packages/cdn/src/cloudinary.ts
@@ -46,7 +46,7 @@ export function cloudinary(
   }
 
   const imageData: ImageData = {
-    imageTypes: options.formats ?? ['webp', 'avif'],
+    imageTypes: options.formats ?? 'auto',
     imageUrlFor(width: number, type: ImageUrlForType = 'jpeg'): string {
       const resizeParams: CloudinaryTransformation = {
         w: width,

--- a/packages/cdn/src/cloudinary.ts
+++ b/packages/cdn/src/cloudinary.ts
@@ -65,13 +65,17 @@ export function cloudinary(
 
       transformations.push(resizeParams);
 
-      const params = transformations
-        .map((transformation) =>
-          Object.entries(transformation)
-            .map(([key, value]) => `${key}_${value}`)
-            .join(','),
-        )
-        .join('/');
+      const pathParameters = transformations.map((transformation) =>
+        Object.entries(transformation)
+          .map(([key, value]) => `${key}_${value}`)
+          .join(','),
+      );
+
+      if (options.auto === 'format') {
+        pathParameters.push('f_auto');
+      }
+
+      const params = pathParameters.join('/');
 
       return `https://res.cloudinary.com/${cloudName}/image/${deliveryType}/${params}/${imageId}${
         deliveryType === 'upload' ? '.' + type : ''
@@ -79,6 +83,9 @@ export function cloudinary(
     },
   };
 
+  if (options.auto) {
+    imageData.auto = options.auto;
+  }
   if (options.aspectRatio) {
     imageData.aspectRatio = options.aspectRatio;
   }

--- a/packages/cdn/src/fastly.ts
+++ b/packages/cdn/src/fastly.ts
@@ -1,7 +1,11 @@
 import { assert, getConfig } from '@responsive-image/core';
 
 import type { Config, CoreOptions } from './types';
-import type { ImageData, ImageType } from '@responsive-image/core';
+import type {
+  ImageData,
+  ImageType,
+  ImageUrlForType,
+} from '@responsive-image/core';
 
 export interface FastlyConfig {
   /**
@@ -84,12 +88,6 @@ export interface FastlyOptions extends CoreOptions {
    * @see https://www.fastly.com/documentation/reference/io/fit/
    */
   fit?: 'bounds' | 'cover' | 'crop';
-  /**
-   * Specifies the desired output encoding for the image.
-   *
-   * @see https://www.fastly.com/documentation/reference/io/format/
-   */
-  formats?: ImageType[];
   /**
    * Extracts the first frame from an animated image sequence (gif).
    *
@@ -216,28 +214,27 @@ export function fastly(image: string, options: FastlyOptions = {}): ImageData {
   // avif is a paid addon, so omitted by default (compared to other CDNs)
   const defaultFormats = config.defaultFormats ?? ['webp'];
 
+  const { formats, aspectRatio, ...fastlyParams } = options;
+
   const imageData: ImageData = {
-    imageTypes: options.formats ?? defaultFormats,
-    imageUrlFor(width: number, type: ImageType = 'jpeg') {
+    imageTypes: formats ?? defaultFormats,
+    imageUrlFor(width: number, type: ImageUrlForType = 'jpeg') {
       const url = new URL(`https://${domain}/${normalizeSrc(image)}`);
       const searchParams = url.searchParams;
 
-      searchParams.set('format', type);
+      searchParams.set('format', type); // fastly supports format=auto
       searchParams.set('width', String(width));
 
-      for (const [key, value] of Object.entries(options)) {
-        if (key === 'aspectRatio') {
-          continue;
-        }
-        searchParams.set(kebabCase(key), value);
+      for (const [key, value] of Object.entries(fastlyParams)) {
+        searchParams.set(kebabCase(key), String(value));
       }
 
       return url.toString();
     },
   };
 
-  if (options.aspectRatio) {
-    imageData.aspectRatio = options.aspectRatio;
+  if (aspectRatio) {
+    imageData.aspectRatio = aspectRatio;
   }
 
   return imageData;

--- a/packages/cdn/src/fastly.ts
+++ b/packages/cdn/src/fastly.ts
@@ -9,7 +9,7 @@ import type {
 
 export interface FastlyConfig {
   /**
-   * By default `fastly` uses the `webp` format.
+   * By default `fastly` uses the `auto` format.
    * Use this to set a different list of default formats.
    */
   defaultFormats?: ImageType[];
@@ -211,8 +211,7 @@ export function fastly(image: string, options: FastlyOptions = {}): ImageData {
     typeof domain === 'string',
   );
 
-  // avif is a paid addon, so omitted by default (compared to other CDNs)
-  const defaultFormats = config.defaultFormats ?? ['webp'];
+  const defaultFormats = config.defaultFormats ?? 'auto';
 
   const { formats, aspectRatio, ...fastlyParams } = options;
 

--- a/packages/cdn/src/imgix.ts
+++ b/packages/cdn/src/imgix.ts
@@ -1,7 +1,7 @@
 import { assert, getConfig } from '@responsive-image/core';
 
 import type { Config, CoreOptions } from './types';
-import type { ImageType, ImageData } from '@responsive-image/core';
+import type { ImageData, ImageUrlForType } from '@responsive-image/core';
 
 export interface ImgixConfig {
   domain: string;
@@ -25,11 +25,11 @@ export function imgix(image: string, options: ImgixOptions = {}): ImageData {
 
   const imageData: ImageData = {
     imageTypes: options.formats ?? ['webp', 'avif'],
-    imageUrlFor(width: number, type: ImageType = 'jpeg'): string {
+    imageUrlFor(width: number, type: ImageUrlForType = 'jpeg'): string {
       const url = new URL(`https://${domain}/${normalizeSrc(image)}`);
       const params = url.searchParams;
 
-      if (options.auto === 'format') {
+      if (type === 'auto') {
         params.set('auto', 'format');
       } else {
         params.set('fm', formatMap[type] ?? type);
@@ -51,9 +51,6 @@ export function imgix(image: string, options: ImgixOptions = {}): ImageData {
     },
   };
 
-  if (options.auto) {
-    imageData.auto = options.auto;
-  }
   if (options.aspectRatio) {
     imageData.aspectRatio = options.aspectRatio;
   }

--- a/packages/cdn/src/imgix.ts
+++ b/packages/cdn/src/imgix.ts
@@ -29,7 +29,11 @@ export function imgix(image: string, options: ImgixOptions = {}): ImageData {
       const url = new URL(`https://${domain}/${normalizeSrc(image)}`);
       const params = url.searchParams;
 
-      params.set('fm', formatMap[type] ?? type);
+      if (options.auto === 'format') {
+        params.set('auto', 'format');
+      } else {
+        params.set('fm', formatMap[type] ?? type);
+      }
       params.set('w', String(width));
       params.set('fit', 'max');
 
@@ -47,6 +51,9 @@ export function imgix(image: string, options: ImgixOptions = {}): ImageData {
     },
   };
 
+  if (options.auto) {
+    imageData.auto = options.auto;
+  }
   if (options.aspectRatio) {
     imageData.aspectRatio = options.aspectRatio;
   }

--- a/packages/cdn/src/imgix.ts
+++ b/packages/cdn/src/imgix.ts
@@ -24,7 +24,7 @@ export function imgix(image: string, options: ImgixOptions = {}): ImageData {
   assert('domain must be set for imgix provider!', typeof domain === 'string');
 
   const imageData: ImageData = {
-    imageTypes: options.formats ?? ['webp', 'avif'],
+    imageTypes: options.formats ?? 'auto',
     imageUrlFor(width: number, type: ImageUrlForType = 'jpeg'): string {
       const url = new URL(`https://${domain}/${normalizeSrc(image)}`);
       const params = url.searchParams;

--- a/packages/cdn/src/netlify.ts
+++ b/packages/cdn/src/netlify.ts
@@ -25,7 +25,7 @@ export function netlify(
   const url = image;
 
   const imageData: ImageData = {
-    imageTypes: options.formats ?? ['webp', 'avif'],
+    imageTypes: options.formats ?? 'auto',
     imageUrlFor(width: number, type: ImageUrlForType = 'jpeg'): string {
       const params = new URLSearchParams({
         url,

--- a/packages/cdn/src/netlify.ts
+++ b/packages/cdn/src/netlify.ts
@@ -30,8 +30,14 @@ export function netlify(
       const params = new URLSearchParams({
         url,
         w: String(width),
-        fm: formatMap[type] ?? type,
       });
+
+      // In Netlify omiting the format parameter
+      // lets the CDN pick a format based on the Accept header
+      // https://docs.netlify.com/image-cdn/overview/#format
+      if (options.auto !== 'format') {
+        params.set('fm', formatMap[type] ?? type);
+      }
 
       if (options.quality) {
         params.set('q', String(options.quality));
@@ -41,6 +47,9 @@ export function netlify(
     },
   };
 
+  if (options.auto) {
+    imageData.auto = options.auto;
+  }
   if (options.aspectRatio) {
     imageData.aspectRatio = options.aspectRatio;
   }

--- a/packages/cdn/src/netlify.ts
+++ b/packages/cdn/src/netlify.ts
@@ -1,7 +1,7 @@
 import { getConfig } from '@responsive-image/core';
 
 import type { Config, CoreOptions } from './types';
-import type { ImageType, ImageData } from '@responsive-image/core';
+import type { ImageData, ImageUrlForType } from '@responsive-image/core';
 
 export interface NetlifyConfig {
   /**
@@ -26,7 +26,7 @@ export function netlify(
 
   const imageData: ImageData = {
     imageTypes: options.formats ?? ['webp', 'avif'],
-    imageUrlFor(width: number, type: ImageType = 'jpeg'): string {
+    imageUrlFor(width: number, type: ImageUrlForType = 'jpeg'): string {
       const params = new URLSearchParams({
         url,
         w: String(width),
@@ -35,7 +35,7 @@ export function netlify(
       // In Netlify omiting the format parameter
       // lets the CDN pick a format based on the Accept header
       // https://docs.netlify.com/image-cdn/overview/#format
-      if (options.auto !== 'format') {
+      if (type !== 'auto') {
         params.set('fm', formatMap[type] ?? type);
       }
 
@@ -47,9 +47,6 @@ export function netlify(
     },
   };
 
-  if (options.auto) {
-    imageData.auto = options.auto;
-  }
   if (options.aspectRatio) {
     imageData.aspectRatio = options.aspectRatio;
   }

--- a/packages/cdn/src/types.ts
+++ b/packages/cdn/src/types.ts
@@ -2,7 +2,7 @@ import type { CloudinaryConfig } from './cloudinary';
 import type { FastlyConfig } from './fastly';
 import type { ImgixConfig } from './imgix';
 import type { NetlifyConfig } from './netlify';
-import type { ImageType } from '@responsive-image/core';
+import type { ImageAuto, ImageType } from '@responsive-image/core';
 
 export interface Config {
   imgix?: ImgixConfig;
@@ -13,6 +13,7 @@ export interface Config {
 
 export interface CoreOptions {
   formats?: ImageType[];
+  auto?: ImageAuto;
   quality?: number;
   aspectRatio?: number;
 }

--- a/packages/cdn/src/types.ts
+++ b/packages/cdn/src/types.ts
@@ -2,7 +2,7 @@ import type { CloudinaryConfig } from './cloudinary';
 import type { FastlyConfig } from './fastly';
 import type { ImgixConfig } from './imgix';
 import type { NetlifyConfig } from './netlify';
-import type { ImageAuto, ImageType } from '@responsive-image/core';
+import type { ImageTypeAuto, ImageType } from '@responsive-image/core';
 
 export interface Config {
   imgix?: ImgixConfig;
@@ -12,8 +12,7 @@ export interface Config {
 }
 
 export interface CoreOptions {
-  formats?: ImageType[];
-  auto?: ImageAuto;
+  formats?: ImageType[] | ImageTypeAuto;
   quality?: number;
   aspectRatio?: number;
 }

--- a/packages/cdn/tests/cloudinary.test.ts
+++ b/packages/cdn/tests/cloudinary.test.ts
@@ -10,10 +10,10 @@ describe('cloudinary', function () {
     setConfig<Config>('cdn', { cloudinary: { cloudName: 'dummy' } });
   });
 
-  test('it supports webp, avif image types by default', function () {
+  test('it lets the CDN choose image type by default', function () {
     const result = cloudinary('foo/bar.jpg');
 
-    expect(result?.imageTypes).toEqual(['webp', 'avif']);
+    expect(result?.imageTypes).toEqual('auto');
   });
 
   test('it supports custom image types', function () {

--- a/packages/cdn/tests/cloudinary.test.ts
+++ b/packages/cdn/tests/cloudinary.test.ts
@@ -89,4 +89,15 @@ describe('cloudinary', function () {
 
     expect(result.aspectRatio).toBe(2);
   });
+
+  test('it supports auto format', function () {
+    const result = cloudinary('foo/bar.jpg', {
+      auto: 'format',
+    });
+
+    expect(result.auto).toBe('format');
+    expect(result.imageUrlFor(100, 'jpeg')).toBe(
+      'https://res.cloudinary.com/dummy/image/upload/w_100,c_limit,q_auto/f_auto/foo/bar.jpeg',
+    );
+  });
 });

--- a/packages/cdn/tests/cloudinary.test.ts
+++ b/packages/cdn/tests/cloudinary.test.ts
@@ -92,12 +92,11 @@ describe('cloudinary', function () {
 
   test('it supports auto format', function () {
     const result = cloudinary('foo/bar.jpg', {
-      auto: 'format',
+      formats: 'auto',
     });
 
-    expect(result.auto).toBe('format');
-    expect(result.imageUrlFor(100, 'jpeg')).toBe(
-      'https://res.cloudinary.com/dummy/image/upload/w_100,c_limit,q_auto/f_auto/foo/bar.jpeg',
+    expect(result.imageUrlFor(100, 'auto')).toBe(
+      'https://res.cloudinary.com/dummy/image/upload/w_100,c_limit,q_auto/f_auto/foo/bar',
     );
   });
 });

--- a/packages/cdn/tests/fastly.test.ts
+++ b/packages/cdn/tests/fastly.test.ts
@@ -10,10 +10,10 @@ describe('fastly', function () {
     setConfig<Config>('cdn', { fastly: { domain: 'image.mydomain.com' } });
   });
 
-  test('it uses the webp format by default', function () {
+  test('it lets the CDN choose image type by default', function () {
     const result = fastly('foo/bar.jpg');
 
-    expect(result?.imageTypes).toEqual(['webp']);
+    expect(result?.imageTypes).toEqual('auto');
   });
 
   test('can set custom default formats (f. ex. add avif)', function () {

--- a/packages/cdn/tests/fastly.test.ts
+++ b/packages/cdn/tests/fastly.test.ts
@@ -64,4 +64,13 @@ describe('fastly', function () {
 
     expect(result.aspectRatio).toBe(2);
   });
+
+  test('it supports auto format', function () {
+    const result = fastly('foo/bar.jpg', {
+      formats: 'auto',
+    });
+    expect(result.imageUrlFor(100, 'auto')).toBe(
+      'https://image.mydomain.com/foo/bar.jpg?format=auto&width=100',
+    );
+  });
 });

--- a/packages/cdn/tests/imgix.test.ts
+++ b/packages/cdn/tests/imgix.test.ts
@@ -67,11 +67,10 @@ describe('imgix', function () {
 
   test('it supports auto format', function () {
     const result = imgix('foo/bar.jpg', {
-      auto: 'format',
+      formats: 'auto',
     });
 
-    expect(result.auto).toBe('format');
-    expect(result.imageUrlFor(100, 'jpeg')).toBe(
+    expect(result.imageUrlFor(100, 'auto')).toBe(
       'https://dummy.imgix.net/foo/bar.jpg?auto=format&w=100&fit=max',
     );
   });

--- a/packages/cdn/tests/imgix.test.ts
+++ b/packages/cdn/tests/imgix.test.ts
@@ -10,10 +10,10 @@ describe('imgix', function () {
     setConfig<Config>('cdn', { imgix: { domain: 'dummy.imgix.net' } });
   });
 
-  test('it supports webp, avif image types by default', function () {
+  test('it lets the CDN choose image type by default', function () {
     const result = imgix('foo/bar.jpg');
 
-    expect(result?.imageTypes).toEqual(['webp', 'avif']);
+    expect(result?.imageTypes).toEqual('auto');
   });
 
   test('it supports custom image types', function () {

--- a/packages/cdn/tests/imgix.test.ts
+++ b/packages/cdn/tests/imgix.test.ts
@@ -64,4 +64,15 @@ describe('imgix', function () {
 
     expect(result.aspectRatio).toBe(2);
   });
+
+  test('it supports auto format', function () {
+    const result = imgix('foo/bar.jpg', {
+      auto: 'format',
+    });
+
+    expect(result.auto).toBe('format');
+    expect(result.imageUrlFor(100, 'jpeg')).toBe(
+      'https://dummy.imgix.net/foo/bar.jpg?auto=format&w=100&fit=max',
+    );
+  });
 });

--- a/packages/cdn/tests/netlify.test.ts
+++ b/packages/cdn/tests/netlify.test.ts
@@ -65,4 +65,15 @@ describe('netlify', function () {
 
     expect(result.aspectRatio).toBe(2);
   });
+
+  test('it supports auto format', function () {
+    const result = netlify('/foo/bar.jpg', {
+      auto: 'format',
+    });
+
+    expect(result.auto).toBe('format');
+    expect(result.imageUrlFor(100, 'jpeg')).toBe(
+      'https://dummy.netlify.app/.netlify/images?url=%2Ffoo%2Fbar.jpg&w=100',
+    );
+  });
 });

--- a/packages/cdn/tests/netlify.test.ts
+++ b/packages/cdn/tests/netlify.test.ts
@@ -68,11 +68,10 @@ describe('netlify', function () {
 
   test('it supports auto format', function () {
     const result = netlify('/foo/bar.jpg', {
-      auto: 'format',
+      formats: 'auto',
     });
 
-    expect(result.auto).toBe('format');
-    expect(result.imageUrlFor(100, 'jpeg')).toBe(
+    expect(result.imageUrlFor(100, 'auto')).toBe(
       'https://dummy.netlify.app/.netlify/images?url=%2Ffoo%2Fbar.jpg&w=100',
     );
   });

--- a/packages/cdn/tests/netlify.test.ts
+++ b/packages/cdn/tests/netlify.test.ts
@@ -10,10 +10,10 @@ describe('netlify', function () {
     setConfig<Config>('cdn', { netlify: { domain: 'dummy.netlify.app' } });
   });
 
-  test('it supports webp, avif image types by default', function () {
+  test('it lets the CDN choose image type by default', function () {
     const result = netlify('/foo/bar.jpg');
 
-    expect(result?.imageTypes).toEqual(['webp', 'avif']);
+    expect(result?.imageTypes).toEqual('auto');
   });
 
   test('it supports custom image types', function () {

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -1,6 +1,6 @@
 import { getDestinationWidthBySize } from './env';
 
-import type { ImageData, ImageType } from './types';
+import type { ImageData, ImageUrlForType } from './types';
 
 export interface ResolveImageOptions {
   /**
@@ -16,7 +16,7 @@ export interface ResolveImageOptions {
   /**
    * preferred image format
    */
-  format?: ImageType;
+  format?: ImageUrlForType;
 }
 
 export function resolveImage(

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -23,9 +23,13 @@ export function resolveImage(
   data: ImageData,
   { width, size, format }: ResolveImageOptions = {},
 ): string | undefined {
+  const imageType =
+    format ??
+    (Array.isArray(data.imageTypes) ? data.imageTypes[0] : data.imageTypes);
+
   const url = data.imageUrlFor(
     width ?? getDestinationWidthBySize(size),
-    format ?? data.imageTypes[0],
+    imageType,
   );
 
   return url;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -27,8 +27,11 @@ export interface Lqip {
   inlineStyles?: ValueOrCallback<Record<string, string | undefined>>;
 }
 
+export type ImageAuto = 'format';
+
 export interface ImageData {
   imageTypes: ImageType[];
+  auto?: ImageAuto;
   availableWidths?: number[];
   aspectRatio?: number;
   imageUrlFor(width: number, type?: ImageType): string | undefined;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -27,14 +27,15 @@ export interface Lqip {
   inlineStyles?: ValueOrCallback<Record<string, string | undefined>>;
 }
 
-export type ImageAuto = 'format';
+export type ImageTypeAuto = 'auto';
+
+export type ImageUrlForType = ImageType | ImageTypeAuto;
 
 export interface ImageData {
-  imageTypes: ImageType[];
-  auto?: ImageAuto;
+  imageTypes: ImageType[] | ImageTypeAuto;
   availableWidths?: number[];
   aspectRatio?: number;
-  imageUrlFor(width: number, type?: ImageType): string | undefined;
+  imageUrlFor(width: number, type?: ImageUrlForType): string | undefined;
   lqip?: Lqip;
 }
 

--- a/packages/react/tests/client.test.tsx
+++ b/packages/react/tests/client.test.tsx
@@ -481,4 +481,32 @@ describe('Response image', () => {
       expect(imgEl).toHaveAttribute('data-ri-lqip', 'test-attr');
     });
   });
+
+  describe('auto format', () => {
+    const imageData: ImageData = {
+      imageTypes: 'auto',
+      imageUrlFor(width, type = 'jpeg') {
+        return `/provider/w${width}/image.webp?format=${type}`;
+      },
+      availableWidths: [50, 100, 640],
+      aspectRatio: 2,
+    };
+
+    test('it renders a srcset on the img tag', () => {
+      const { container } = render(<ResponsiveImage src={imageData} />);
+      const imgEl = container.querySelector('img')!;
+
+      expect(imgEl).toHaveAttribute(
+        'srcset',
+        '/provider/w50/image.webp?format=auto 50w, /provider/w100/image.webp?format=auto 100w, /provider/w640/image.webp?format=auto 640w',
+      );
+    });
+
+    test('it omits the picture and source tags', () => {
+      const { container } = render(<ResponsiveImage src={imageData} />);
+
+      expect(container.querySelector('picture')).not.toBeInTheDocument();
+      expect(container.querySelector('source')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/solid/tests/client.test.tsx
+++ b/packages/solid/tests/client.test.tsx
@@ -681,4 +681,32 @@ describe('ResponsiveImage', () => {
       expect(imgEl).toHaveAttribute('data-ri-lqip', 'test-attr');
     });
   });
+
+  describe('auto format', () => {
+    const imageData: ImageData = {
+      imageTypes: 'auto',
+      imageUrlFor(width, type = 'jpeg') {
+        return `/provider/w${width}/image.webp?format=${type}`;
+      },
+      availableWidths: [50, 100, 640],
+      aspectRatio: 2,
+    };
+
+    test('it renders a srcset on the img tag', () => {
+      const { container } = render(() => <ResponsiveImage src={imageData} />);
+      const imgEl = container.querySelector('img')!;
+
+      expect(imgEl).toHaveAttribute(
+        'srcset',
+        '/provider/w50/image.webp?format=auto 50w, /provider/w100/image.webp?format=auto 100w, /provider/w640/image.webp?format=auto 640w',
+      );
+    });
+
+    test('it omits the picture and source tags', () => {
+      const { container } = render(() => <ResponsiveImage src={imageData} />);
+
+      expect(container.querySelector('picture')).not.toBeInTheDocument();
+      expect(container.querySelector('source')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/svelte/tests/responsive-image.test.svelte.ts
+++ b/packages/svelte/tests/responsive-image.test.svelte.ts
@@ -528,4 +528,32 @@ describe('ResponsiveImage', () => {
 			expect(imgEl).toHaveAttribute('data-ri-lqip', 'test-attr');
 		});
 	});
+
+	describe('auto format', () => {
+		const imageData: ImageData = {
+			imageTypes: 'auto',
+			imageUrlFor(width, type = 'jpeg') {
+				return `/provider/w${width}/image.webp?format=${type}`;
+			},
+			availableWidths: [50, 100, 640],
+			aspectRatio: 2
+		};
+
+		test('it renders a srcset on the img tag', () => {
+			const { container } = render(ResponsiveImage, { src: imageData });
+			const imgEl = container.querySelector('img');
+
+			expect(imgEl).toHaveAttribute(
+				'srcset',
+				'/provider/w50/image.webp?format=auto 50w, /provider/w100/image.webp?format=auto 100w, /provider/w640/image.webp?format=auto 640w'
+			);
+		});
+
+		test('it omits the picture and source tags', () => {
+			const { container } = render(ResponsiveImage, { src: imageData });
+
+			expect(container.querySelector('picture')).not.toBeInTheDocument();
+			expect(container.querySelector('source')).not.toBeInTheDocument();
+		});
+	});
 });

--- a/packages/wc/src/responsive-image.ts
+++ b/packages/wc/src/responsive-image.ts
@@ -32,7 +32,6 @@ const typeScore = new Map<ImageType | ImageTypeAuto, number>([
   ['jpeg', 1],
   ['webp', 2],
   ['avif', 3],
-  ['auto', 4],
 ]);
 
 @customElement('responsive-image')

--- a/packages/wc/src/responsive-image.ts
+++ b/packages/wc/src/responsive-image.ts
@@ -205,6 +205,7 @@ export class ResponsiveImage extends LitElement {
         width=${ifDefined(this.imgWidth)}
         height=${ifDefined(this.imgHeight)}
         class=${classMap(classes)}
+        loading=${this.loading}
         style=${styleMap(styles)}
         srcset=${ifDefined(
           imageTypes === 'auto'
@@ -214,7 +215,6 @@ export class ResponsiveImage extends LitElement {
         )}
         src=${ifDefined(this.imgSrc)}
         alt=${this.alt}
-        loading=${this.loading}
         decoding=${this.decoding}
         crossorigin=${ifDefined(this.crossOrigin)}
         fetchpriority=${ifDefined(this.fetchPriority)}

--- a/packages/wc/src/responsive-image.ts
+++ b/packages/wc/src/responsive-image.ts
@@ -172,7 +172,7 @@ export class ResponsiveImage extends LitElement {
   }
 
   render() {
-    const { lqip } = this.src;
+    const { lqip, auto } = this.src;
 
     if (lqip?.class) {
       throw new Error(
@@ -195,6 +195,44 @@ export class ResponsiveImage extends LitElement {
           ...(lqip?.inlineStyles ? getValueOrCallback(lqip.inlineStyles) : {}),
         };
 
+    const img = html`
+      <img
+        part="img"
+        width=${ifDefined(this.imgWidth)}
+        height=${ifDefined(this.imgHeight)}
+        class=${classMap(classes)}
+        style=${styleMap(styles)}
+        srcset=${ifDefined(
+          auto === 'format'
+            ? // auto format assumes only one entry in sources
+              this.sources[0].srcset
+            : undefined,
+        )}
+        src=${ifDefined(this.imgSrc)}
+        alt=${this.alt}
+        loading=${this.loading}
+        decoding=${this.decoding}
+        crossorigin=${ifDefined(this.crossOrigin)}
+        fetchpriority=${ifDefined(this.fetchPriority)}
+        referrerpolicy=${ifDefined(this.referrerPolicy)}
+        data-ri-lqip=${ifDefined(lqip?.attribute)}
+        @load=${(event: Event) => {
+          this.complete = true;
+          this.dispatchEvent(new Event(event.type, event));
+        }}
+        @error=${(event: Event) => {
+          this.dispatchEvent(new ErrorEvent(event.type, event));
+        }}
+        @abort=${(event: Event) => {
+          this.dispatchEvent(new Event(event.type, event));
+        }}
+      />
+    `;
+
+    if (auto === 'format') {
+      return img;
+    }
+
     return html`
       <picture>
         ${this.sourcesSorted.map(
@@ -205,31 +243,7 @@ export class ResponsiveImage extends LitElement {
               sizes=${s.sizes ?? nothing}
             />`,
         )}
-        <img
-          part="img"
-          width=${ifDefined(this.imgWidth)}
-          height=${ifDefined(this.imgHeight)}
-          class=${classMap(classes)}
-          style=${styleMap(styles)}
-          src=${ifDefined(this.imgSrc)}
-          alt=${this.alt}
-          loading=${this.loading}
-          decoding=${this.decoding}
-          crossorigin=${ifDefined(this.crossOrigin)}
-          fetchpriority=${ifDefined(this.fetchPriority)}
-          referrerpolicy=${ifDefined(this.referrerPolicy)}
-          data-ri-lqip=${ifDefined(lqip?.attribute)}
-          @load=${(event: Event) => {
-            this.complete = true;
-            this.dispatchEvent(new Event(event.type, event));
-          }}
-          @error=${(event: Event) => {
-            this.dispatchEvent(new ErrorEvent(event.type, event));
-          }}
-          @abort=${(event: Event) => {
-            this.dispatchEvent(new Event(event.type, event));
-          }}
-        />
+        ${img}
       </picture>
     `;
   }

--- a/packages/wc/src/responsive-image.ts
+++ b/packages/wc/src/responsive-image.ts
@@ -1,7 +1,6 @@
 import {
   type ImageData,
-  type ImageType,
-  type ImageTypeAuto,
+  type ImageUrlForType,
   env,
   getDestinationWidthBySize,
   getValueOrCallback,
@@ -14,7 +13,7 @@ import { type StyleInfo, styleMap } from 'lit/directives/style-map.js';
 
 interface ImageSource {
   srcset: string;
-  type: ImageType | ImageTypeAuto;
+  type: ImageUrlForType;
   mimeType?: string;
   sizes?: string;
 }
@@ -27,7 +26,7 @@ enum Layout {
 const PIXEL_DENSITIES = [1, 2];
 
 // determines the order of sources, prefereing next-gen formats over legacy
-const typeScore = new Map<ImageType | ImageTypeAuto, number>([
+const typeScore = new Map<ImageUrlForType, number>([
   ['png', 1],
   ['jpeg', 1],
   ['webp', 2],

--- a/packages/wc/test/responsive-image.test.ts
+++ b/packages/wc/test/responsive-image.test.ts
@@ -628,10 +628,9 @@ describe('ResponsiveImage', () => {
 
   describe('auto format', () => {
     const imageData: ImageData = {
-      auto: 'format',
-      imageTypes: ['webp'],
+      imageTypes: 'auto',
       imageUrlFor(width, type = 'jpeg') {
-        return `/provider/w${width}/image.${type}?format=auto`;
+        return `/provider/w${width}/image.webp?format=${type}`;
       },
       availableWidths: [50, 100, 640],
       aspectRatio: 2,

--- a/packages/wc/test/responsive-image.test.ts
+++ b/packages/wc/test/responsive-image.test.ts
@@ -4,8 +4,7 @@ import { html } from 'lit';
 import { describe, expect, test, afterEach } from 'vitest';
 
 import { trigger } from './image-helper.js';
-
-import type { ResponsiveImage } from '../src/responsive-image.js';
+import { type ResponsiveImage } from '../src/responsive-image.js';
 
 import '../src/responsive-image.js';
 
@@ -624,6 +623,39 @@ describe('ResponsiveImage', () => {
       await trigger(imgEl!);
 
       expect(imgEl).not.toHaveStyle('border-left: solid 5px red');
+    });
+  });
+
+  describe('auto format', () => {
+    const imageData: ImageData = {
+      auto: 'format',
+      imageTypes: ['webp'],
+      imageUrlFor(width, type = 'jpeg') {
+        return `/provider/w${width}/image.${type}?format=auto`;
+      },
+      availableWidths: [50, 100, 640],
+      aspectRatio: 2,
+    };
+
+    test('it renders a srcset on the img tag', async () => {
+      const el = await fixture<ResponsiveImage>(
+        html`<responsive-image .src=${imageData}></responsive-image>`,
+      );
+      const imgEl = el.shadowRoot?.querySelector('img');
+
+      expect(imgEl).toHaveAttribute(
+        'srcset',
+        '/provider/w50/image.webp?format=auto 50w, /provider/w100/image.webp?format=auto 100w, /provider/w640/image.webp?format=auto 640w',
+      );
+    });
+
+    test('it omits the picture and source tags', async () => {
+      const el = await fixture<ResponsiveImage>(
+        html`<responsive-image .src=${imageData}></responsive-image>`,
+      );
+
+      expect(el.shadowRoot?.querySelector('picture')).not.toBeInTheDocument();
+      expect(el.shadowRoot?.querySelector('source')).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
Checking in with a draft PR to see if this approach makes sense.

I considered adding `'auto'` to `ImageType`, but `'auto'` and other entries in `formats` would be mutually exclusive. If it were an `ImageType` we would get it as a parameter directly in `imageUrlFor` and would not have to set it on `imageData` in the various CDN functions. 

Searching for `'auto'` in `imageTypes` inside the components is a bit clunky though. I think I prefer some kind of flag such as this one on `ImageData`.

It could maybe be a boolean flag instead of a string, but I see for example [imgix has several other "auto" features](https://docs.imgix.com/en-US/apis/rendering/automatic#format). Figured a string would be more future-proof.

Closes #1342 