### PR TITLE
Fix changesets CI

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
 packages:
   - 'packages/*'
   - 'apps/*'
+
+# changesets in release CI workflow is failing to handle package with custom prettier plugins without this
+publicHoistPattern:
+  - '*prettier-plugin*'


### PR DESCRIPTION
Seems changesets in CI is trying to run prettier, but failing for packages with custom plugins:

```
Error: Cannot find package 'prettier-plugin-ember-template-tag' imported from /home/runner/work/responsive-image/responsive-image/noop.js
```

Hope this will fix it.