### PR TITLE
Add local search to docsite, update team page

### DIFF
--- a/.changeset/rotten-dodos-film.md
+++ b/.changeset/rotten-dodos-film.md
@@ -1,0 +1,5 @@
+---
+'@responsive-image/react': patch
+---
+
+Add missing README

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -16,15 +16,14 @@ export default defineConfig({
       { text: 'Docs', link: '/intro/what' },
       {
         text: 'About',
-        // link: '/usage/concepts',
         items: [
           {
             text: 'Releases',
             link: 'https://github.com/simonihmig/responsive-image/releases',
           },
           {
-            text: 'Me',
-            link: '/me',
+            text: 'Team',
+            link: '/team',
           },
           {
             text: 'History',

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -118,6 +118,10 @@ export default defineConfig({
       },
     ],
 
+    search: {
+      provider: 'local',
+    },
+
     socialLinks: [
       {
         icon: 'github',

--- a/apps/docs/src/history.md
+++ b/apps/docs/src/history.md
@@ -1,6 +1,8 @@
 # History of the project
 
-This project has its roots in late 2016, when Andreas Schacht, my then co-worker, and [me](./me.md) started to work on `ember-responsive-image`. This came out of the need to render optimized responsive images in our framkework of choice [Ember.js](https://emberjs.com/), for client projects at [kaliber5](https://www.kaliber5.de), the consultancy that I co-founded.
+_Simon Ihmig_
+
+This project has its roots in late 2016, when Andreas Schacht, my then co-worker, and [me](./team.md) started to work on `ember-responsive-image`. This came out of the need to render optimized responsive images in our framkework of choice [Ember.js](https://emberjs.com/), for client projects at [kaliber5](https://www.kaliber5.de), the consultancy that I co-founded.
 
 As strong believers in open source software, and as this proved to be useful for others as well, we started the project in the open on GitHub, see the [first commit](https://github.com/simonihmig/responsive-image/commit/1718f0c6d113d21309cb3800338c944d5ba90943). Don't look too closely at the code though, 2016 was different! 😅
 

--- a/apps/docs/src/team.md
+++ b/apps/docs/src/team.md
@@ -1,3 +1,6 @@
+---
+layout: page
+---
 <script setup>
 import {
   VPTeamPage,
@@ -18,11 +21,25 @@ const members = [
       { icon: 'mastodon', link: 'https://fosstodon.org/@simonihmig' },
     ]
   },
+  {
+    avatar: 'https://www.github.com/wkillerud.png',
+    name: 'William Killerud',
+    title: 'Senior Developer',
+    org: 'Vend',
+    links: [
+      { icon: 'github', link: 'https://github.com/wkillerud' },
+      { icon: 'mastodon', link: 'https://social.lol/@dub' },
+    ]
+  },
 ]
 </script>
 
-# About me
+<VPTeamPage>
+  <VPTeamPageTitle>
+    <template #title>
+      Our Team
+    </template>
 
-<VPTeamMembers
-    :members="members"
-  />
+  </VPTeamPageTitle>
+  <VPTeamMembers :members />
+</VPTeamPage>

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,17 @@
+# @responsive-image/react
+
+React component to render responsive images, provided as locally processed images or loaded remotely from Image CDNs.
+
+Part of the [ResponsiveImage](https://github.com/simonihmig/responsive-image) project.
+
+## Compatibility
+
+- React 18 or above
+
+## Documentation
+
+Visit [responsive-image.dev](https://responsive-image.dev) for our complete documentation site.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE.md).


### PR DESCRIPTION
Adds a local search (as opposed to using Algolia) and updates the team page as you suggested. I looked for a way to redirect from `/me` to `/team`, but didn't find any such feature in Vitepress.

I also noticed on NPM that I forgot the `README` for the React package as well. Not sure it warrants a patch on its own, but I added a changeset for it in any case.