### PR TITLE
Add config to set explicit device width for fallback

### DIFF
--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -81,6 +81,10 @@ export default defineConfig({
             text: 'LQIP',
             link: '/lqip',
           },
+          {
+            text: 'Configure',
+            link: '/configure',
+          }
         ],
       },
       {

--- a/apps/docs/src/usage/configure.md
+++ b/apps/docs/src/usage/configure.md
@@ -1,0 +1,14 @@
+# Configure
+
+Using the `setConfig` method you can configure what device widths ResponsiveImage considers when generating the `<picture>`'s `<source>` list by overriding `deviceWidths`.
+
+By default the largest device width is used as the source for the `<img>` tag fallback. If you want to override that value, set `fallbackScreenWidth`.
+
+```ts
+import { type EnvConfig, setConfig } from '@responsive-image/core';
+
+setConfig<EnvConfig>('env', {
+  deviceWidths: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
+  fallbackScreenWidth: 3840,
+});
+```

--- a/apps/ember-test-app/app/app.ts
+++ b/apps/ember-test-app/app/app.ts
@@ -2,7 +2,7 @@ import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from 'ember-test-app/config/environment';
-import { setConfig } from '@responsive-image/core';
+import { type EnvConfig, setConfig } from '@responsive-image/core';
 import type { Config } from '@responsive-image/cdn';
 
 export default class App extends Application {
@@ -24,6 +24,11 @@ setConfig<Config>('cdn', {
   netlify: {
     domain: 'responsive-image.dev',
   },
+});
+
+// Integration test for #1558
+setConfig<EnvConfig>('env', {
+  fallbackScreenWidth: 1280,
 });
 
 loadInitializers(App, config.modulePrefix);

--- a/apps/ember-test-app/tests/fastboot/cloudinary-test.js
+++ b/apps/ember-test-app/tests/fastboot/cloudinary-test.js
@@ -15,7 +15,7 @@ module('FastBoot | Cloudinary', function (hooks) {
       .dom('img[data-test-image]')
       .hasAttribute(
         'src',
-        'https://res.cloudinary.com/responsive-image/image/upload/w_3840,c_limit,q_auto/f_auto/aurora-original_w0sk6h',
+        'https://res.cloudinary.com/responsive-image/image/upload/w_1280,c_limit,q_auto/f_auto/aurora-original_w0sk6h',
       );
   });
 });

--- a/apps/ember-test-app/tests/fastboot/fastly-test.js
+++ b/apps/ember-test-app/tests/fastboot/fastly-test.js
@@ -15,7 +15,7 @@ module('FastBoot | Fastly', function (hooks) {
       .dom('img[data-test-image]')
       .hasAttribute(
         'src',
-        'https://www.fastly.io/image.webp?format=auto&width=3840',
+        'https://www.fastly.io/image.webp?format=auto&width=1280',
       );
   });
 });

--- a/apps/ember-test-app/tests/fastboot/imgix-test.js
+++ b/apps/ember-test-app/tests/fastboot/imgix-test.js
@@ -15,7 +15,7 @@ module('FastBoot | Imgix', function (hooks) {
       .dom('img[data-test-image]')
       .hasAttribute(
         'src',
-        'https://responsive-image.imgix.net/aurora-original.jpg?auto=format&w=3840&fit=max',
+        'https://responsive-image.imgix.net/aurora-original.jpg?auto=format&w=1280&fit=max',
       );
   });
 });

--- a/apps/ember-test-app/tests/fastboot/netlify-test.js
+++ b/apps/ember-test-app/tests/fastboot/netlify-test.js
@@ -15,7 +15,7 @@ module('FastBoot | Netlify', function (hooks) {
       .dom('img[data-test-image]')
       .hasAttribute(
         'src',
-        'https://responsive-image.dev/.netlify/images?url=aurora-original.jpg&w=3840',
+        'https://responsive-image.dev/.netlify/images?url=aurora-original.jpg&w=1280',
       );
   });
 });

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -6,7 +6,7 @@ export const env: Env = {
   get screenWidth(): number {
     return typeof screen !== 'undefined'
       ? screen.width
-      : (env.deviceWidths.at(-1) ?? 320);
+      : (getConfig<EnvConfig>('env')?.fallbackScreenWidth ?? env.deviceWidths.at(-1) ?? 320);
   },
   get physicalWidth(): number {
     return env.screenWidth * env.devicePixelRatio;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -54,4 +54,10 @@ export interface Env {
 
 export interface EnvConfig {
   deviceWidths?: number[];
+  /**
+   * By default the size for the `img` tag fallback is set to the largest {@link deviceWidths}.
+   *
+   * Set this to an explicit size if you want to change that behavior.
+   */
+  fallbackScreenWidth?: number;
 }

--- a/packages/core/tests/env.test.ts
+++ b/packages/core/tests/env.test.ts
@@ -39,6 +39,11 @@ describe('env', () => {
     test('defaults to largest deviceWidth', () => {
       expect(env.screenWidth).toBe(3840);
     });
+
+    test('can be changed with the fallbackScreenWidth setting', () => {
+      setConfig<EnvConfig>('env', { fallbackScreenWidth: 1280 });
+      expect(env.screenWidth).toBe(1280);
+    });
   });
 
   describe('devicePixelRatio', () => {


### PR DESCRIPTION
Suggested fix for #1558

It's not a custom size per image though, but at least it lets users set a ballpark size not in the 4K range if they prefer.