### PR TITLE
Adds Vite ^7.x as peerDep

### DIFF
--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -73,7 +73,7 @@
     "vitest": "3.2.4"
   },
   "peerDependencies": {
-    "vite": "^5.2.0 || ^6.0.0"
+    "vite": "^5.2.0 || ^6.0.0 || ^7.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Works fine with Vite v7, but should fix the ```vite is listed by your project with version 7.0.5 which doesn't satisfy what @responsive-image/vite-plugin and other dependencies request (^6.1.0).``` warning