### PR TITLE
Fix flakiness of blurhash playwright test

### DIFF
--- a/packages/-internals/src/playwright/index.ts
+++ b/packages/-internals/src/playwright/index.ts
@@ -221,10 +221,10 @@ export function runTests({ isShadowDom = false }: TestOptions = {}) {
         'src',
         /assets\/aurora-\d+w([-.][a-zA-Z0-9-_]+)?\.jpg/,
       );
-      await expect(img).toHaveAttribute(
-        'data-ri-lqip',
-        'bh:5:3:M53T;oR8D8y.t2M.oxylRoRlHYniyBRQXR',
-      );
+      // Blurhash encoding seems to suffer from some indeterminism based on external factors, causing test flakiness.
+      // See https://github.com/woltapp/blurhash/issues/196.
+      // Therefore not comparing with exact expected result.
+      await expect(img).toHaveAttribute('data-ri-lqip', /^bh:5:3:M53T.{30}$/);
 
       for (const [type, ext] of imageTypes) {
         await expect(


### PR DESCRIPTION
Seeing the bluarhash playwright test failing from time to time with:

```
      Error: Timed out 10000ms waiting for expect(locator).toHaveAttribute(expected)
  
      Locator: locator('[data-test-local-image="fixed,lqip-blurhash"]')
      Expected string: "bh:5:3:M53T;oR8D8y.t2M.oxylRoRlHYniyBRQXR"
      Received string: "bh:5:3:M53KT1R8D8y.t2M.oxylRoRlHYniyBRQXR"
```