### PR TITLE
Fix flakey blurhash test, 2nd attempt

### DIFF
--- a/packages/-internals/src/playwright/index.ts
+++ b/packages/-internals/src/playwright/index.ts
@@ -233,7 +233,7 @@ export function runTests({ isShadowDom = false }: TestOptions = {}) {
       // Blurhash encoding seems to suffer from some indeterminism based on external factors, causing test flakiness.
       // See https://github.com/woltapp/blurhash/issues/196.
       // Therefore not comparing with exact expected result.
-      await expect(img).toHaveAttribute('data-ri-lqip', /^bh:5:3:M53T.{30}$/);
+      await expect(img).toHaveAttribute('data-ri-lqip', /^bh:5:3:.{34}$/);
 
       for (const [type, ext] of imageTypes) {
         await expect(


### PR DESCRIPTION
Following up on #1606, 2nd attempt after this started to fail again: https://github.com/simonihmig/responsive-image/actions/runs/17582545540/job/49942231476 