### PR TITLE
Setup trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write  # Required for trusted publishung using OIDC
+  contents: write
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
@@ -25,4 +29,3 @@ jobs:
           publish: pnpm changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
After recent npm supply chain attacks, I have revoked my npm token and set up [trusted publishing](https://docs.npmjs.com/trusted-publishers) for all this repo's packages. This is updating the release workflow to be able to generate the OIDC token.

Will need to see if the next release will work with this new setup...