### PR TITLE
Delay pulling new package releases for 3 days

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# wait 3d before installing new releases, to protect against malicious and/or unpublished packages
+minimumReleaseAge: 4320

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,10 @@
   "labels": ["dependencies"],
   "packageRules": [
     {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days"
+    },
+    {
       "matchCurrentVersion": ">= 1.0.0",
       "matchUpdateTypes": ["minor"],
       "automerge": true


### PR DESCRIPTION
To decrease the risk of malicious/unpublished package releases.