### PR TITLE
feat(cdn): add Autorender image CDN provider

### DIFF
--- a/.changeset/autorender-cdn-provider.md
+++ b/.changeset/autorender-cdn-provider.md
@@ -1,0 +1,6 @@
+---
+'@responsive-image/cdn': minor
+'@responsive-image/ember': minor
+---
+
+Add Autorender image CDN provider

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -114,6 +114,7 @@ export default defineConfig({
         link: '/',
         base: '/cdn',
         items: [
+          { text: 'Autorender', link: '/autorender' },
           { text: 'Cloudinary', link: '/cloudinary' },
           { text: 'Fastly', link: '/fastly' },
           { text: 'Imgix', link: '/imgix' },

--- a/apps/docs/src/cdn/autorender.md
+++ b/apps/docs/src/cdn/autorender.md
@@ -1,0 +1,160 @@
+---
+outline: [2, 3]
+---
+
+# Autorender
+
+The image processing capabilities of the [Autorender](https://autorender.io) image CDN are supported by a helper function provided to you by this library.
+
+## Setup
+
+Make sure you have the `@responsive-image/cdn` package installed:
+
+::: code-group
+
+```bash [npm]
+npm install @responsive-image/cdn
+```
+
+```bash [yarn]
+yarn add @responsive-image/cdn
+```
+
+```bash [pnpm]
+pnpm add @responsive-image/cdn
+```
+
+:::
+
+You need to specify your Autorender `domain` and `workspace` in your configuration, which you can set up in your application (e.g. `app.js`). The workspace ID is the public routing identifier in your delivery URLs and is not a secret:
+
+```js
+import { setConfig } from '@responsive-image/core';
+
+setConfig('cdn', {
+  autorender: {
+    domain: 'assets.autorender.io',
+    workspace: 'wB5HrlVhGq',
+  },
+});
+```
+
+## Usage
+
+> [!IMPORTANT]
+> Please make sure you have read the section on [remote images](../usage/remote-images.md) first.
+
+Use the autorender provider function passing the source path of the image inside your workspace, and pass the return value to the [image component](../usage/component.md):
+
+::: code-group
+
+```gjs [Ember .gjs]
+import { ResponsiveImage } from '@responsive-image/ember';
+import { autorender } from '@responsive-image/cdn';
+
+<template>
+  <ResponsiveImage @src={{autorender 'products/chair.jpg'}} />
+</template>
+```
+
+```hbs [Ember .hbs]
+<ResponsiveImage @src={{responsive-image-autorender 'products/chair.jpg'}} />
+```
+
+```ts [Lit]
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { autorender } from '@responsive-image/cdn';
+import '@responsive-image/wc';
+
+@customElement('my-app')
+export class MyApp extends LitElement {
+  render() {
+    return html`<responsive-image
+      .src=${autorender('products/chair.jpg')}
+    ></responsive-image>`;
+  }
+}
+```
+
+```tsx [React]
+import { ResponsiveImage } from '@responsive-image/react';
+import { autorender } from '@responsive-image/cdn';
+
+export default function MyApp() {
+  return <ResponsiveImage src={autorender('products/chair.jpg')} />;
+}
+```
+
+```tsx [Solid]
+import { ResponsiveImage } from '@responsive-image/solid';
+import { autorender } from '@responsive-image/cdn';
+
+export default function MyApp() {
+  return <ResponsiveImage src={autorender('products/chair.jpg')} />;
+}
+```
+
+```svelte [Svelte]
+<script>
+  import { ResponsiveImage } from '@responsive-image/svelte';
+  import { autorender } from '@responsive-image/cdn';
+</script>
+
+<ResponsiveImage src={autorender('products/chair.jpg')} />
+```
+
+```vue [Vue]
+<script setup>
+import { ResponsiveImage } from '@responsive-image/vue';
+import { autorender } from '@responsive-image/cdn';
+</script>
+
+<template>
+  <ResponsiveImage :src="autorender('products/chair.jpg')" />
+</template>
+```
+
+:::
+
+### Aspect Ratio
+
+For the image component to be able to render `width` and `height` attributes to prevent layout shifts after loading has completed, it needs to know the aspect ratio of the source image. Unlike [local images](../usage/local-images.md) it cannot know this upfront for remote images, that's why it is recommended to supply the `aspectRatio` parameter if possible:
+
+```ts [Lit]
+autorender('products/chair.jpg', {
+  aspectRatio: 1.5,
+});
+```
+
+### Quality
+
+Use the `quality` parameter to pass a custom quality setting (`1`–`100`) instead of Autorender's per-format default:
+
+```ts [Lit]
+autorender('products/chair.jpg', {
+  quality: 50,
+});
+```
+
+### Image formats
+
+By default the component lets Autorender select the format from the request `Accept` header.
+
+If you want a `picture` tag with one or more specific formats as `source` tags you can specify them using the `formats` argument. Autorender supports `avif`, `webp`, `jpeg`, and `png`:
+
+```ts [Lit]
+autorender('products/chair.jpg', {
+  formats: ['avif', 'webp'],
+});
+```
+
+### Custom transforms
+
+Besides the resizing and format tokens the library adds implicitly, you can append any additional [Autorender transform tokens](https://www.autorender.io/docs/transformations/introduction) verbatim by passing a `transforms` array:
+
+```ts [Lit]
+autorender('products/chair.jpg', {
+  transforms: ['e_sharpen', 'br_16'],
+});
+```

--- a/apps/docs/src/cdn/index.md
+++ b/apps/docs/src/cdn/index.md
@@ -6,6 +6,7 @@ With image CDNs the image processing is offloaded to the Cloud. This allows for 
 
 The following image CDNs are supported by the `@responsive-image/cdn` package out of the box:
 
+- [Autorender](./autorender.md)
 - [Cloudinary](./cloudinary.md)
 - [Fastly](./fastly.md)
 - [Imgix](./imgix.md)

--- a/apps/ember-vite/app/app.js
+++ b/apps/ember-vite/app/app.js
@@ -12,6 +12,10 @@ export default class App extends Application {
 }
 
 setConfig('cdn', {
+  autorender: {
+    domain: 'assets.autorender.io',
+    workspace: 'wB5HrlVhGq',
+  },
   cloudinary: {
     cloudName: 'responsive-image',
   },

--- a/apps/ember-vite/app/templates/index.hbs
+++ b/apps/ember-vite/app/templates/index.hbs
@@ -20,6 +20,13 @@
   data-test-cloudinary-image
 />
 
+<h2>Autorender</h2>
+
+<ResponsiveImage
+  @src={{responsive-image-autorender "ar-juice.jpg"}}
+  data-test-autorender-image
+/>
+
 <h2>Fastly</h2>
 
 <ResponsiveImage @src={{responsive-image-fastly "image.webp" aspectRatio=2}} />

--- a/apps/ember-webpack/app/app.ts
+++ b/apps/ember-webpack/app/app.ts
@@ -12,6 +12,10 @@ export default class App extends Application {
 }
 
 setConfig<Config>('cdn', {
+  autorender: {
+    domain: 'assets.autorender.io',
+    workspace: 'wB5HrlVhGq',
+  },
   cloudinary: {
     cloudName: 'responsive-image',
   },

--- a/apps/ember-webpack/app/templates/index.hbs
+++ b/apps/ember-webpack/app/templates/index.hbs
@@ -20,6 +20,13 @@
   data-test-cloudinary-image
 />
 
+<h2>Autorender</h2>
+
+<ResponsiveImage
+  @src={{responsive-image-autorender "ar-juice.jpg"}}
+  data-test-autorender-image
+/>
+
 <h2>Fastly</h2>
 
 <ResponsiveImage @src={{responsive-image-fastly "image.webp" aspectRatio=2}} />

--- a/apps/nuxt/app/app.vue
+++ b/apps/nuxt/app/app.vue
@@ -2,6 +2,7 @@
 import { ResponsiveImage } from '@responsive-image/vue';
 import {
   cloudinary,
+  autorender,
   fastly,
   imgix,
   netlify,
@@ -17,6 +18,10 @@ import imageGray from './images/aurora.jpg?grayscale&responsive';
 import { setConfig } from '@responsive-image/core';
 
 setConfig<Config>('cdn', {
+  autorender: {
+    domain: 'assets.autorender.io',
+    workspace: 'wB5HrlVhGq',
+  },
   cloudinary: {
     cloudName: 'responsive-image',
   },
@@ -51,6 +56,11 @@ setConfig<Config>('cdn', {
         })
       "
       data-test-cloudinary-image
+    />
+    <h2>Autorender</h2>
+    <ResponsiveImage
+      :src="autorender('ar-juice.jpg')"
+      data-test-autorender-image
     />
     <h2>Fastly</h2>
     <ResponsiveImage

--- a/apps/react-vite/src/main.tsx
+++ b/apps/react-vite/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { cloudinary, imgix, netlify } from '@responsive-image/cdn';
+import { autorender, cloudinary, imgix, netlify } from '@responsive-image/cdn';
 import { setConfig } from '@responsive-image/core';
 import { ResponsiveImage } from '@responsive-image/react';
 
@@ -13,6 +13,10 @@ import imagePortrait from './images/aurora.jpg?aspect=2:3&allowUpscale&responsiv
 import imageGray from './images/aurora.jpg?grayscale&responsive';
 
 setConfig('cdn', {
+  autorender: {
+    domain: 'assets.autorender.io',
+    workspace: 'wB5HrlVhGq',
+  },
   cloudinary: {
     cloudName: 'responsive-image',
   },
@@ -38,6 +42,11 @@ createRoot(document.getElementById('root')!).render(
           aspectRatio: 1.4971927636,
         })}
         data-test-cloudinary-image
+      />
+      <h2>Autorender</h2>
+      <ResponsiveImage
+        src={autorender('ar-juice.jpg')}
+        data-test-autorender-image
       />
       <h2>imgix</h2>
       <ResponsiveImage

--- a/apps/solid-start/src/app.tsx
+++ b/apps/solid-start/src/app.tsx
@@ -8,6 +8,10 @@ import { setConfig } from '@responsive-image/core';
 import type { Config } from '@responsive-image/cdn';
 
 setConfig<Config>('cdn', {
+  autorender: {
+    domain: 'assets.autorender.io',
+    workspace: 'wB5HrlVhGq',
+  },
   cloudinary: {
     cloudName: 'responsive-image',
   },

--- a/apps/solid-start/src/routes/index.tsx
+++ b/apps/solid-start/src/routes/index.tsx
@@ -1,4 +1,10 @@
-import { cloudinary, fastly, imgix, netlify } from '@responsive-image/cdn';
+import {
+  autorender,
+  cloudinary,
+  fastly,
+  imgix,
+  netlify,
+} from '@responsive-image/cdn';
 import { ResponsiveImage } from '@responsive-image/solid';
 import image from '../images/aurora.jpg?responsive';
 import imageLqipColor from '../images/aurora.jpg?lqip=color&responsive';
@@ -22,6 +28,11 @@ export default function Home() {
           aspectRatio: 1.4971927636,
         })}
         data-test-cloudinary-image
+      />
+      <h2>Autorender</h2>
+      <ResponsiveImage
+        src={autorender('ar-juice.jpg')}
+        data-test-autorender-image
       />
       <h2>Fastly</h2>
       <ResponsiveImage

--- a/apps/svelte-kit/src/routes/+page.svelte
+++ b/apps/svelte-kit/src/routes/+page.svelte
@@ -2,6 +2,7 @@
   import { ResponsiveImage } from '@responsive-image/svelte';
   import {
     cloudinary,
+    autorender,
     fastly,
     imgix,
     netlify,
@@ -17,6 +18,10 @@
   import { setConfig } from '@responsive-image/core';
 
   setConfig<Config>('cdn', {
+    autorender: {
+      domain: 'assets.autorender.io',
+      workspace: 'wB5HrlVhGq',
+    },
     cloudinary: {
       cloudName: 'responsive-image',
     },
@@ -46,6 +51,8 @@
   })}
   data-test-cloudinary-image
 />
+<h2>Autorender</h2>
+<ResponsiveImage src={autorender('ar-juice.jpg')} data-test-autorender-image />
 <h2>Fastly</h2>
 <ResponsiveImage
   src={fastly('image.webp', { aspectRatio: 2 })}

--- a/apps/wc-lit/src/app.ts
+++ b/apps/wc-lit/src/app.ts
@@ -1,6 +1,12 @@
 import { LitElement, css, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { cloudinary, fastly, imgix, netlify } from '@responsive-image/cdn';
+import {
+  autorender,
+  cloudinary,
+  fastly,
+  imgix,
+  netlify,
+} from '@responsive-image/cdn';
 import { setConfig } from '@responsive-image/core';
 import '@responsive-image/wc';
 import image from './images/aurora.jpg?responsive';
@@ -14,6 +20,10 @@ import imageGray from './images/aurora.jpg?grayscale&responsive';
 import type { Config } from '@responsive-image/cdn';
 
 setConfig<Config>('cdn', {
+  autorender: {
+    domain: 'assets.autorender.io',
+    workspace: 'wB5HrlVhGq',
+  },
   cloudinary: {
     cloudName: 'responsive-image',
   },
@@ -46,6 +56,13 @@ export class MyApp extends LitElement {
       <responsive-image
         .src=${cloudinary('aurora-original_w0sk6h', { aspectRatio: 1.4971927636 })}
         data-test-cloudinary-image
+      ></responsive-image>
+
+      <h2>Autorender</h2>
+
+      <responsive-image
+        .src=${autorender('ar-juice.jpg')}
+        data-test-autorender-image
       ></responsive-image>
 
       <h2>Fastly</h2>

--- a/packages/cdn/src/autorender.ts
+++ b/packages/cdn/src/autorender.ts
@@ -1,0 +1,82 @@
+import { assert, getConfig } from '@responsive-image/core';
+
+import type { Config, CoreOptions } from './types';
+import type { ImageData, ImageUrlForType } from '@responsive-image/core';
+
+export interface AutorenderConfig {
+  /**
+   * Delivery domain that serves your transformed images,
+   * e.g. `assets.autorender.io`.
+   */
+  domain: string;
+  /**
+   * Public workspace ID that routes the request, e.g. `wB5HrlVhGq`.
+   * It is part of the delivery URL and is not a secret.
+   */
+  workspace: string;
+}
+
+export interface AutorenderOptions extends CoreOptions {
+  /**
+   * Extra Autorender transform tokens applied verbatim, e.g.
+   * `['e_sharpen', 'br_16']`. See the transformation reference for the
+   * full token vocabulary.
+   */
+  transforms?: string[];
+}
+
+const ABSOLUTE_URL_RE = /^https?:\/\//i;
+
+function normalizeSrc(src: string): string {
+  const normalized = src.trim();
+  return normalized[0] === '/' ? normalized.slice(1) : normalized;
+}
+
+export function autorender(
+  image: string,
+  options: AutorenderOptions = {},
+): ImageData {
+  const config = getConfig<Config>('cdn')?.autorender;
+  const domain = config?.domain;
+  const workspace = config?.workspace;
+  assert(
+    'domain must be set for the autorender provider!',
+    typeof domain === 'string',
+  );
+  assert(
+    'workspace must be set for the autorender provider!',
+    typeof workspace === 'string',
+  );
+  assert(
+    'absolute URLs are not supported by the autorender provider!',
+    !ABSOLUTE_URL_RE.test(image.trim()),
+  );
+
+  const src = normalizeSrc(image);
+
+  const imageData: ImageData = {
+    imageTypes: options.formats ?? 'auto',
+    imageUrlFor(width: number, type: ImageUrlForType = 'jpeg'): string {
+      const tokens = [...(options.transforms ?? [])];
+
+      tokens.push(`w_${width}`);
+
+      // Autorender accepts `f_jpeg` directly, so the format name maps 1:1.
+      // `auto` emits `f_auto`, letting Autorender negotiate from the
+      // Accept header instead of pinning a single format.
+      tokens.push(`f_${type}`);
+
+      if (options.quality) {
+        tokens.push(`q_${options.quality}`);
+      }
+
+      return `https://${domain}/${workspace}/${tokens.join(',')}/${src}`;
+    },
+  };
+
+  if (options.aspectRatio) {
+    imageData.aspectRatio = options.aspectRatio;
+  }
+
+  return imageData;
+}

--- a/packages/cdn/src/index.ts
+++ b/packages/cdn/src/index.ts
@@ -1,3 +1,4 @@
+export * from './autorender.ts';
 export * from './cloudinary.ts';
 export * from './fastly.ts';
 export * from './imgix.ts';

--- a/packages/cdn/src/types.ts
+++ b/packages/cdn/src/types.ts
@@ -1,3 +1,4 @@
+import type { AutorenderConfig } from './autorender';
 import type { CloudinaryConfig } from './cloudinary';
 import type { FastlyConfig } from './fastly';
 import type { ImgixConfig } from './imgix';
@@ -5,6 +6,7 @@ import type { NetlifyConfig } from './netlify';
 import type { ImageTypeAuto, ImageType } from '@responsive-image/core';
 
 export interface Config {
+  autorender?: AutorenderConfig;
   imgix?: ImgixConfig;
   fastly?: FastlyConfig;
   cloudinary?: CloudinaryConfig;

--- a/packages/cdn/tests/autorender.test.ts
+++ b/packages/cdn/tests/autorender.test.ts
@@ -1,0 +1,96 @@
+import { setConfig } from '@responsive-image/core';
+import { beforeAll, describe, expect, test } from 'vitest';
+
+import { autorender } from '../src';
+
+import type { Config } from '../src';
+
+describe('autorender', function () {
+  beforeAll(() => {
+    setConfig<Config>('cdn', {
+      autorender: { domain: 'assets.autorender.io', workspace: 'wB5HrlVhGq' },
+    });
+  });
+
+  test('it lets the CDN choose image type by default', function () {
+    const result = autorender('products/chair.jpg');
+
+    expect(result?.imageTypes).toEqual('auto');
+  });
+
+  test('it supports custom image types', function () {
+    const result = autorender('products/chair.jpg', {
+      formats: ['jpeg', 'webp'],
+    });
+
+    expect(result?.imageTypes).toEqual(['jpeg', 'webp']);
+  });
+
+  test('it returns correct image URLs', function () {
+    const result = autorender('products/chair.jpg');
+
+    expect(result.imageUrlFor(100, 'jpeg')).toBe(
+      'https://assets.autorender.io/wB5HrlVhGq/w_100,f_jpeg/products/chair.jpg',
+    );
+
+    expect(result.imageUrlFor(1000, 'webp')).toBe(
+      'https://assets.autorender.io/wB5HrlVhGq/w_1000,f_webp/products/chair.jpg',
+    );
+  });
+
+  test('it normalizes a leading slash in the source path', function () {
+    const result = autorender('/products/chair.jpg');
+
+    expect(result.imageUrlFor(100, 'jpeg')).toBe(
+      'https://assets.autorender.io/wB5HrlVhGq/w_100,f_jpeg/products/chair.jpg',
+    );
+  });
+
+  test('it emits f_auto for the auto type', function () {
+    const result = autorender('products/chair.jpg', { formats: 'auto' });
+
+    expect(result.imageUrlFor(100, 'auto')).toBe(
+      'https://assets.autorender.io/wB5HrlVhGq/w_100,f_auto/products/chair.jpg',
+    );
+  });
+
+  test('it supports custom quality setting', function () {
+    const result = autorender('products/chair.jpg', { quality: 50 });
+
+    expect(result.imageUrlFor(100, 'jpeg')).toBe(
+      'https://assets.autorender.io/wB5HrlVhGq/w_100,f_jpeg,q_50/products/chair.jpg',
+    );
+  });
+
+  test('it appends custom transform tokens', function () {
+    const result = autorender('products/chair.jpg', {
+      transforms: ['e_sharpen', 'br_16'],
+    });
+
+    expect(result.imageUrlFor(100, 'jpeg')).toBe(
+      'https://assets.autorender.io/wB5HrlVhGq/e_sharpen,br_16,w_100,f_jpeg/products/chair.jpg',
+    );
+  });
+
+  test('it applies the requested width after custom transforms', function () {
+    const result = autorender('products/chair.jpg', {
+      transforms: ['w_50'],
+    });
+
+    expect(result.imageUrlFor(100, 'jpeg')).toBe(
+      'https://assets.autorender.io/wB5HrlVhGq/w_50,w_100,f_jpeg/products/chair.jpg',
+    );
+  });
+
+  test('it supports custom aspectRatio', function () {
+    const result = autorender('products/chair.jpg', { aspectRatio: 2 });
+
+    expect(result.aspectRatio).toBe(2);
+  });
+
+  test('it rejects absolute URLs', function () {
+    expect(() => autorender('https://images.example.com/chair.jpg')).toThrow(
+      'absolute URLs are not supported by the autorender provider!',
+    );
+  });
+});

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -88,6 +88,7 @@
     "main": "addon-main.cjs",
     "app-js": {
       "./components/responsive-image.js": "./dist/_app_/components/responsive-image.js",
+      "./helpers/responsive-image-autorender.js": "./dist/_app_/helpers/responsive-image-autorender.js",
       "./helpers/responsive-image-cloudinary.js": "./dist/_app_/helpers/responsive-image-cloudinary.js",
       "./helpers/responsive-image-fastly.js": "./dist/_app_/helpers/responsive-image-fastly.js",
       "./helpers/responsive-image-imgix.js": "./dist/_app_/helpers/responsive-image-imgix.js",

--- a/packages/ember/src/helpers/responsive-image-autorender.ts
+++ b/packages/ember/src/helpers/responsive-image-autorender.ts
@@ -1,0 +1,1 @@
+export { autorender as default } from '@responsive-image/cdn';

--- a/packages/ember/src/template-registry.ts
+++ b/packages/ember/src/template-registry.ts
@@ -1,4 +1,5 @@
 import type ResponsiveImageComponent from './components/responsive-image.gts';
+import type AutorenderProvider from './helpers/responsive-image-autorender';
 import type CloudinaryProvider from './helpers/responsive-image-cloudinary';
 import type FastlyProvider from './helpers/responsive-image-fastly';
 import type ImgixProvider from './helpers/responsive-image-imgix.ts';
@@ -8,6 +9,7 @@ import type ResponsiveImageResolve from './helpers/responsive-image-resolve.ts';
 export default interface Registry {
   ResponsiveImage: typeof ResponsiveImageComponent;
   'responsive-image-resolve': typeof ResponsiveImageResolve;
+  'responsive-image-autorender': typeof AutorenderProvider;
   'responsive-image-cloudinary': typeof CloudinaryProvider;
   'responsive-image-fastly': typeof FastlyProvider;
   'responsive-image-netlify': typeof NetlifyProvider;

--- a/packages/ember/tests/integration/helpers/responsive-image-autorender-test.gts
+++ b/packages/ember/tests/integration/helpers/responsive-image-autorender-test.gts
@@ -1,0 +1,10 @@
+import { autorender } from '@responsive-image/cdn';
+import { module, test } from 'qunit';
+
+import responsiveImageAutorender from '../../../src/helpers/responsive-image-autorender.ts';
+
+module('Integration | Helper | responsive-image-autorender', function () {
+  test('it re-exports autorender provider from cdn package', function (assert) {
+    assert.strictEqual(responsiveImageAutorender, autorender);
+  });
+});


### PR DESCRIPTION
Adds Autorender as a `@responsive-image/cdn` provider, alongside imgix/cloudinary/fastly/netlify.

[Autorender](https://autorender.io) transforms and delivers images and videos straight from a URL. You put transform tokens in the path; the CDN returns the processed asset, resized and encoded in the best format each browser supports. Same path-segment model as cloudinary, which is why it drops cleanly into this abstraction.

Disclosure: I'm a co-founder of Autorender. I went to wire our CDN into responsive-image and found the provider abstraction made it a small, self-contained job — the whole thing falls out of `imageUrlFor`. Sending it upstream rather than keeping a private fork.

**What's here**
- `autorender()` provider — path-segment transform grammar (like cloudinary), `w_`/`f_`/`q_` tokens, `formats: 'auto'` default so the CDN negotiates format from the `Accept` header
- Remote-fetch mode (cloudinary parity): a full `http(s)` source becomes a `fetch_<url>` token
- `aspectRatio`, `quality`, and pass-through `transforms` options
- Full test coverage (exact-URL assertions, mirrors `imgix.test.ts`), docs page, sidebar entry, changeset

**Verify without signup** — these resolve publicly and match exactly what the provider emits:
- base: `https://assets.autorender.io/LOKVTtKVGb/doc1/ar-juice.jpg` (306 KB jpeg)
- `imageUrlFor(800, 'webp')`: `https://assets.autorender.io/LOKVTtKVGb/w_800,f_webp/doc1/ar-juice.jpg` (24.7 KB webp)
- `imageUrlFor(400, 'avif')` + `q_60`: `https://assets.autorender.io/LOKVTtKVGb/w_400,f_avif,q_60/doc1/ar-juice.jpg` (8.7 KB avif)

Happy to adjust naming, scope, or docs to fit your conventions. No hard feelings if it's not a fit for the project's direction.
